### PR TITLE
chore(python): migrate setup.py to setuptools

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -1,6 +1,5 @@
 # min (1/2) x'Q'x - q'x
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 import aa

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,11 +1,10 @@
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup
+from setuptools.extension import Extension
 from Cython.Build import cythonize
 
 aa_extension = Extension(
     name="aa",
     sources=["aapy.pyx"],
-    library_dirs=["../src"],
     include_dirs=["../include"],
     libraries=['lapack', 'blas']
 )
@@ -15,4 +14,3 @@ setup(
     version='0.0.1',
     ext_modules=cythonize([aa_extension])
 )
-


### PR DESCRIPTION
## Summary
- Replace `distutils` with `setuptools` (distutils was removed in Python 3.12).
- Drop `library_dirs=["../src"]`; `aa.c` is textually included via `cdef extern`, not linked, and `lapack`/`blas` are resolved from system paths.
- Drop `from __future__ import print_function` from `example.py` (it already uses f-strings, so Py2 compat is moot).

## Test plan
- [ ] \`cd python && python setup.py build_ext --inplace\` on Python 3.12+ still builds.
- [ ] \`python example.py\` runs (requires numpy + matplotlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)