### PR TITLE
docs: fix README API signatures and header docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,29 @@ python example.py
 The Python API is as follows. To initialize the accelerator:
 ```python
 import aa
-aa_wrk = aa.AndersonAccelerator(dim, mem, type1, eta)
+aa_wrk = aa.AndersonAccelerator(dim, mem, type1=False, regularization=1e-12,
+                                relaxation=1.0, safeguard_factor=1.0,
+                                max_weight_norm=1e6, verbosity=0)
 ```
 where:
-* `dim` is the integer problem dimension.
-* `mem` is the integer amount of memory (or lookback) you want the algorithm to use, around 10 is a good number for this. 
-* `type1` is a boolean, if `True` uses type-1 AA, otherwise uses type-2 AA.
-* `regularization`: float, regularization param, type-I: 1e-8 works well, type-II: more stable can use 1e-10 often
-* `relaxation`: float in [0,2], mixing parameter (1.0 is vanilla AA)
-* `verbosity`: verbosity level, if greater than 0 prints out various info
+* `dim`: integer problem dimension.
+* `mem`: integer amount of memory (or lookback) to use; around 10 is a good starting point.
+* `type1`: bool, if `True` uses type-I AA, otherwise type-II.
+* `regularization`: float, regularization param (multiplied internally by `||M||_F`); type-I: 1e-8 works well, type-II can use 1e-10 / 1e-12.
+* `relaxation`: float in `[0, 2]`, mixing parameter (1.0 is vanilla AA).
+* `safeguard_factor`: float, tolerance used by `safeguard`; larger is more aggressive but less stable.
+* `max_weight_norm`: float, reject AA steps whose weight vector norm exceeds this.
+* `verbosity`: int, if greater than 0 prints diagnostic info.
 
 To use the accelerator:
 ```python
-aa_wrk.apply(x, x_prev)
+aa_wrk.apply(x, x_prev)                  # in-place accelerate x
+aa_wrk.safeguard(x_after_map, x_prev)    # optional stability check
+aa_wrk.reset()                           # discard history, keep workspace
 ```
-where:
-* `x` is the numpy array consisting of the current iterate and it will be overwritten with the accelerated iterate.
-* `x_prev` is the numpy array consisting of the previous iterate (the input to the update function).
+* `apply(x, x_prev)`: `x` is the current iterate (output of the map applied to `x_prev`), overwritten in place with the accelerated iterate; `x_prev` is the previous iterate.
+* `safeguard(f_new, x_new)`: optional safeguard after applying the map to the accelerated point. If rejected, `f_new` and `x_new` are restored to their pre-AA values.
+* Arrays passed to `apply`/`safeguard` must be C-contiguous `float64`.
 
 
 C
@@ -56,45 +62,29 @@ C
 At the command prompt type `make` to compile the library and the example. The
 example can be run by `out/gd`.
 
-The C API is as follows:
+The C API (see `include/aa.h` for full docstrings) is:
 
 ```C
-/* Initialize Anderson Acceleration, allocates memory.
- *
- * Args:
- *  dim: the dimension of the variable for aa
- *  mem: the memory (number of past iterations used) for aa
- *  type1: bool, if True use type 1 aa, otherwise use type 2
- *  regularization: float, regularization param, type-I and type-II different
- *       for type-I: 1e-8 works well, type-II: more stable can use 1e-10 often
- *  relaxation: float \in [0,2], mixing parameter (1.0 is vanilla AA)
- *  verbosity: if greater than 0 prints out various info
-
- * Reurns:
- *  Pointer to aa workspace
- */
+/* Initialize an AA workspace; returns NULL on invalid params or alloc failure. */
 AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
-                aa_float relaxation, aa_int verbosity);
+                aa_float relaxation, aa_float safeguard_factor,
+                aa_float max_weight_norm, aa_int verbosity);
 
-/* Apply Anderson Acceleration.
- *
- * Args:
- *  f: output of map at current iteration, overwritten with aa output at end.
- *  x: input to map at current iteration
- *  a: aa workspace from aa_init
- *
- * Returns:
- *  (float) (+ or -) norm of AA weights vector:
- *    if positive then update was accepted and f contains new point
- *    if negative then update was rejected and f is unchanged
- */
+/* Apply AA. f is overwritten with the accelerated iterate; x is the previous
+ * iterate (input to the map). Returns the (signed) norm of the AA weights:
+ * positive => accepted, negative => rejected and f is unchanged. */
 aa_float aa_apply(aa_float *f, const aa_float *x, AaWork *a);
 
-/* Finish Anderson Acceleration, clears memory.
- *
- * Args:
- *  a: aa workspace from aa_init.
- */
+/* Optional safeguard: if the AA step made the residual grow too much, revert
+ * f_new and x_new to the pre-AA values. Returns 0 on accept, -1 on reject. */
+aa_int aa_safeguard(aa_float *f_new, aa_float *x_new, AaWork *a);
+
+/* Discard history; keep workspace allocations. Useful after a divergent step. */
+void aa_reset(AaWork *a);
+
+/* Free the workspace. */
 void aa_finish(AaWork *a);
 ```
+
+`AaWork` is not thread-safe: one workspace per thread.
 

--- a/include/aa.h
+++ b/include/aa.h
@@ -17,18 +17,23 @@ typedef struct ACCEL_WORK AaWork;
 /**
  * Initialize Anderson Acceleration, allocates memory.
  *
+ * NOTE: an AaWork instance is not thread-safe; allocate one per thread.
+ *
  * @param dim               the dimension of the variable for AA
  * @param mem               the memory (number of past iterations used) for AA
  * @param type1             if True use type 1 AA, otherwise use type 2
- * @param regularization    type-I and type-II different, for type-I: 1e-8 works
- *                          well, type-II: more stable can use 1e-12 often
+ * @param regularization    non-negative; internally scaled by ||M||_F, so pass
+ *                          a relative value, not an absolute one. Type-I: 1e-8
+ *                          works well, type-II can use 1e-12.
  * @param relaxation        float \in [0,2], mixing parameter (1.0 is vanilla)
  * @param safeguard_factor  factor that controls safeguarding checks
  *                          larger is more aggressive but less stable
- * @param max_weight_norm   float, maximum norm of AA weights
+ * @param max_weight_norm   float > 0, reject steps whose weight norm exceeds
+ *                          this threshold
  * @param verbosity         if greater than 0 prints out various info
  *
- * @return pointer to AA workspace
+ * @return pointer to AA workspace, or NULL if parameters are invalid or memory
+ *         allocation fails
  *
  */
 AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,


### PR DESCRIPTION
## Summary
- README Python section listed a \`eta\` parameter that doesn't exist, and the C signature was missing \`safeguard_factor\` and \`max_weight_norm\`. Both are now up to date with the actual code, and \`safeguard\`/\`reset\` are documented.
- Fix the "Reurns" → "Returns" typo in the README.
- \`aa.h\`: note that \`regularization\` is multiplied internally by \`||M||_F\` (users were passing absolute values), document the \`NULL\` return contract, and add a thread-safety note.

## Test plan
- [ ] Render README and spot-check formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)