### PR TITLE
fix: blas_int consistency in gd.c/run_tests.c, complete SFLOAT

### DIFF
--- a/examples/gd.c
+++ b/examples/gd.c
@@ -57,8 +57,9 @@ static aa_float rand_float(void) {
  */
 int main(int argc, char **argv) {
   aa_int type1 = TYPE1, n = DIM, iters = ITERS, memory = MEM, seed = SEED;
-  aa_int i, one = 1;
+  aa_int i;
   aa_int verbosity = VERBOSITY;
+  blas_int bn, bone = 1;
   aa_float neg_step_size = -STEPSIZE;
   aa_float regularization = REGULARIZATION;
   aa_float relaxation = RELAXATION;
@@ -113,8 +114,9 @@ int main(int argc, char **argv) {
     Qhalf[i] = rand_float();
   }
 
+  bn = (blas_int)n;
   BLAS(gemm)
-  ("Trans", "No", &n, &n, &n, &onef, Qhalf, &n, Qhalf, &n, &zerof, Q, &n);
+  ("Trans", "No", &bn, &bn, &bn, &onef, Qhalf, &bn, Qhalf, &bn, &zerof, Q, &bn);
 
   /* add small amount regularization */
   for (i = 0; i < n; i++) {
@@ -133,13 +135,13 @@ int main(int argc, char **argv) {
     memcpy(xprev, x, sizeof(aa_float) * n);
     /* x = x - step_size * Q * xprev */
     BLAS(gemv)
-    ("No", &n, &n, &neg_step_size, Q, &n, xprev, &one, &onef, x, &one);
+    ("No", &bn, &bn, &neg_step_size, Q, &bn, xprev, &bone, &onef, x, &bone);
 
     _tic(&aa_timer);
     aa_safeguard(x, xprev, a);
     aa_time += _tocq(&aa_timer);
 
-    err = BLAS(nrm2)(&n, x, &one);
+    err = BLAS(nrm2)(&bn, x, &bone);
     if (i % PRINT_INTERVAL == 0) {
       printf("Iter: %i, Err %.4e\n", i, err);
     }

--- a/include/aa.h
+++ b/include/aa.h
@@ -9,7 +9,11 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef SFLOAT
 typedef double aa_float;
+#else
+typedef float aa_float;
+#endif
 typedef int aa_int;
 
 typedef struct ACCEL_WORK AaWork;

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -55,8 +55,9 @@ static aa_float rand_float(void) {
 
 static const char *gd(aa_int type1, aa_float relaxation) {
   aa_int n = DIM, iters = ITERS, memory = MEM, seed = SEED;
-  aa_int i, one = 1;
+  aa_int i;
   aa_int verbosity = VERBOSITY;
+  blas_int bn = (blas_int)n, bone = 1;
   aa_float neg_step_size = -STEPSIZE;
   aa_float safeguard_tolerance = SAFEGUARD_TOLERANCE;
   aa_float max_aa_norm = MAX_AA_NORM;
@@ -87,7 +88,7 @@ static const char *gd(aa_int type1, aa_float relaxation) {
   }
 
   BLAS(gemm)
-  ("Trans", "No", &n, &n, &n, &onef, Qhalf, &n, Qhalf, &n, &zerof, Q, &n);
+  ("Trans", "No", &bn, &bn, &bn, &onef, Qhalf, &bn, Qhalf, &bn, &zerof, Q, &bn);
 
   /* add small amount regularization */
   for (i = 0; i < n; i++) {
@@ -106,13 +107,13 @@ static const char *gd(aa_int type1, aa_float relaxation) {
     memcpy(xprev, x, sizeof(aa_float) * n);
     /* x = x - step_size * Q * xprev */
     BLAS(gemv)
-    ("No", &n, &n, &neg_step_size, Q, &n, xprev, &one, &onef, x, &one);
+    ("No", &bn, &bn, &neg_step_size, Q, &bn, xprev, &bone, &onef, x, &bone);
 
     _tic(&aa_timer);
     aa_safeguard(x, xprev, a);
     aa_time += _tocq(&aa_timer);
 
-    err = BLAS(nrm2)(&n, x, &one);
+    err = BLAS(nrm2)(&bn, x, &bone);
     if (i % PRINT_INTERVAL == 0) {
       printf("Iter: %i, Err %.4e\n", i, err);
     }


### PR DESCRIPTION
## Summary
- \`gd.c\` and \`run_tests.c\` passed \`aa_int*\` (always \`int*\`) to BLAS routines prototyped as \`blas_int*\`. Under \`-DBLAS64\` (where \`blas_int\` is \`int64_t\`), BLAS reads 8 bytes from a 4-byte int — silently broken. Introduce \`blas_int\` locals (\`bn\`, \`bone\`) and use them for BLAS calls; leave \`n\`/\`one\` as \`aa_int\` for \`aa_init\`.
- \`aa.h\` hardcoded \`aa_float = double\`, while \`aa_blas.h\` already had an \`SFLOAT\` branch selecting single-precision BLAS routines. Building with \`-DSFLOAT\` thus called \`sgemm\`/\`sgemv\` with double-sized data. Make \`aa_float\` switch on \`SFLOAT\` too so the feature is internally consistent.

## Test plan
- [x] \`make && out/run_tests\` — all tests pass (default double build).
- [ ] \`CC="cc -DSFLOAT" make\` — if you want to exercise the SFLOAT path.
- [ ] \`CC="cc -DBLAS64" make\` — for the BLAS64 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)