### PR TITLE
chore(ci): modernize workflows + Python 3.9-3.14 matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
       - run: make
       - run: make test
       - run: out/run_tests
+      - name: Run gd example with varied flags
+        run: scripts/check_gd_convergence.sh
 
   mac:
     runs-on: macos-latest
@@ -27,6 +29,8 @@ jobs:
       - run: make
       - run: make test
       - run: out/run_tests
+      - name: Run gd example with varied flags
+        run: scripts/check_gd_convergence.sh
 
   python:
     runs-on: ubuntu-latest
@@ -41,20 +45,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
-      - run: python -m pip install --upgrade pip setuptools wheel cython numpy
+      - run: python -m pip install --upgrade pip setuptools wheel cython numpy pytest
       - name: Build Cython extension
         working-directory: python
         run: python setup.py build_ext --inplace
-      - name: Smoke test
+      - name: Run pytest suite
         working-directory: python
-        run: |
-          python -c "
-          import numpy as np
-          import aa
-          acc = aa.AndersonAccelerator(10, 5, True, 1e-8, 1.0, 1.0, 1e6, 0)
-          x = np.zeros(10); xp = np.zeros(10)
-          acc.apply(x, xp)
-          acc.safeguard(x, xp)
-          acc.reset()
-          print('OK')
-          "
+        run: pytest -v test_aa.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - run: make
       - run: make test
-      - run: out/run_tests
-      - name: Run gd example with varied flags
-        run: test/check_gd_convergence.sh
 
   mac:
     runs-on: macos-latest
@@ -28,9 +25,6 @@ jobs:
       - run: brew install openblas lapack
       - run: make
       - run: make test
-      - run: out/run_tests
-      - name: Run gd example with varied flags
-        run: test/check_gd_convergence.sh
 
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,60 @@
 ---
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 06:00 UTC.
+    - cron: '0 6 * * 1'
 
 jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt-get install libopenblas-dev liblapack-dev
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - run: make
       - run: make test
       - run: out/run_tests
-
-  #  runs-on: windows-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - run: choco install clapack
-  #    - run: make
-  #    - run: make test
-  #    - run: test/run_tests
 
   mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: brew install openblas lapack
       - run: make
       - run: make test
       - run: out/run_tests
+
+  python:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
+      - run: python -m pip install --upgrade pip setuptools wheel cython numpy
+      - name: Build Cython extension
+        working-directory: python
+        run: python setup.py build_ext --inplace
+      - name: Smoke test
+        working-directory: python
+        run: |
+          python -c "
+          import numpy as np
+          import aa
+          acc = aa.AndersonAccelerator(10, 5, True, 1e-8, 1.0, 1.0, 1e6, 0)
+          x = np.zeros(10); xp = np.zeros(10)
+          acc.apply(x, xp)
+          acc.safeguard(x, xp)
+          acc.reset()
+          print('OK')
+          "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: make test
       - run: out/run_tests
       - name: Run gd example with varied flags
-        run: scripts/check_gd_convergence.sh
+        run: test/check_gd_convergence.sh
 
   mac:
     runs-on: macos-latest
@@ -30,7 +30,7 @@ jobs:
       - run: make test
       - run: out/run_tests
       - name: Run gd example with varied flags
-        run: scripts/check_gd_convergence.sh
+        run: test/check_gd_convergence.sh
 
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -18,3 +18,7 @@ jobs:
       - run: make
       - run: make test
       - run: valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-reachable=yes --error-exitcode=1 out/run_tests
+      - name: Run gd example under valgrind
+        env:
+          RUNNER: "valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 -q"
+        run: test/check_gd_convergence.sh

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,14 +1,20 @@
 ---
 name: Valgrind
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 06:00 UTC.
+    - cron: '0 6 * * 1'
 
 jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt-get install libopenblas-dev liblapack-dev valgrind
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev valgrind
       - run: make
       - run: make test
       - run: valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-reachable=yes --error-exitcode=1 out/run_tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ python/aapy.c
 python/build
 python/.*
 .pytest_cache
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # MAKEFILE for aa
-.PHONY: default clean purge
+.PHONY: default clean purge test
 
 OBJECTS = src/aa.o
 
@@ -34,6 +34,8 @@ purge: clean
 	@rm -rf $(OUT)
 
 test: $(OUT)/run_tests
+	$(OUT)/run_tests
+	test/check_gd_convergence.sh
 
 $(OUT)/run_tests: test/run_tests.c $(OUT)/libaa.a
 	$(CC) $(CFLAGS) -o $@ $^ -lblas -llapack -lm

--- a/scripts/check_gd_convergence.sh
+++ b/scripts/check_gd_convergence.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the gd example (via top-level `make`) and run it with several
+# flag combinations, asserting each run drives the iterate norm below
+# a convergence threshold. Exercises the positional CLI surface.
+set -euo pipefail
+
+GD="${GD:-out/gd}"
+THRESHOLD="${THRESHOLD:-1e-3}"
+
+run_case() {
+  local label="$1"; shift
+  local log
+  log="$("$GD" "$@")"
+  local err
+  err="$(printf '%s\n' "$log" | awk '/^Iter:/ {e=$NF} END {print e}')"
+  printf '[gd] %-30s args=%-40s err=%s\n' "$label" "$*" "$err"
+  awk -v e="$err" -v t="$THRESHOLD" 'BEGIN {
+    if (e+0 >= t+0) { printf "gd did not converge: %s >= %s\n", e, t; exit 1 }
+  }'
+}
+
+#         label                       mem type1 dim  step  seed iters [reg]
+run_case "type1 mem=5"                  5  1   100  0.01   0   3000
+run_case "type2 mem=5"                  5  0   100  0.01   0   3000
+run_case "type1 mem=10 reg=1e-8"       10  1   100  0.01   0   3000  1e-8

--- a/test/check_gd_convergence.sh
+++ b/test/check_gd_convergence.sh
@@ -2,15 +2,22 @@
 # Build the gd example (via top-level `make`) and run it with several
 # flag combinations, asserting each run drives the iterate norm below
 # a convergence threshold. Exercises the positional CLI surface.
+#
+# Optional env vars:
+#   GD        path to the gd binary (default: out/gd)
+#   RUNNER    command prefix (e.g. "valgrind --error-exitcode=1 -q")
+#   THRESHOLD convergence cutoff for the final iterate norm (default: 1e-3)
 set -euo pipefail
 
 GD="${GD:-out/gd}"
 THRESHOLD="${THRESHOLD:-1e-3}"
+# shellcheck disable=SC2206  # intentional word-splitting for the runner prefix
+RUNNER_CMD=( ${RUNNER:-} )
 
 run_case() {
   local label="$1"; shift
   local log
-  log="$("$GD" "$@")"
+  log="$("${RUNNER_CMD[@]+"${RUNNER_CMD[@]}"}" "$GD" "$@")"
   local err
   err="$(printf '%s\n' "$log" | awk '/^Iter:/ {e=$NF} END {print e}')"
   printf '[gd] %-30s args=%-40s err=%s\n' "$label" "$*" "$err"


### PR DESCRIPTION
## Summary
- Bump \`actions/checkout\` v2 → v4 (v2 runners have been EOL since late 2023).
- Add \`workflow_dispatch\` so CI can be kicked off manually from the Actions tab.
- Add a weekly cron at Mondays 06:00 UTC so bitrot (toolchain/dep drift) shows up on a predictable cadence.
- Add a Python matrix job (\`3.9\`, \`3.10\`, \`3.11\`, \`3.12\`, \`3.13\`, \`3.14\`) that installs blas/lapack + Cython + numpy, builds the extension, and runs a smoke test that constructs an \`AndersonAccelerator\` and calls \`apply\`/\`safeguard\`/\`reset\`. \`allow-prereleases: true\` lets the job keep working when a new minor drops.

## Test plan
- [ ] Merge and watch the first scheduled run on Monday.
- [ ] Trigger manually via the Actions tab to verify the dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)