### PR TITLE
chore: fix gd.c usage/fallthroughs, make make test actually run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # MAKEFILE for aa
-.PHONY: default clean purge
+.PHONY: default clean purge test
 
 OBJECTS = src/aa.o
 
 PROFILING = 0
 CFLAGS += -g -Wall -O3 -Iinclude -DPROFILING=$(PROFILING)
+# Override on the command line to link against MKL, OpenBLAS-only, etc.
+# `-lm` is needed by run_tests (sqrt, fabs); harmless for gd.
+LDLIBS ?= -lblas -llapack -lm
 
 SRC_FILES = $(wildcard src/*.c)
 INC_FILES = $(wildcard include/*.h)
@@ -26,15 +29,18 @@ $(OUT)/libaa.a: $(OBJECTS)
 	- ranlib $@
 
 $(OUT)/gd: examples/gd.c $(OUT)/libaa.a
-	$(CC) $(CFLAGS) -o $@ $^ -lblas -llapack
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:
 	@rm -rf $(OBJECTS)
 purge: clean
 	@rm -rf $(OUT)
 
+# `make test` builds and runs the suite; use `make $(OUT)/run_tests` if you
+# only want to build it.
 test: $(OUT)/run_tests
+	$(OUT)/run_tests
 
 $(OUT)/run_tests: test/run_tests.c $(OUT)/libaa.a
-	$(CC) $(CFLAGS) -o $@ $^ -lblas -llapack -lm
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 

--- a/examples/gd.c
+++ b/examples/gd.c
@@ -52,8 +52,12 @@ static aa_float rand_float(void) {
 }
 
 /*
- * out/gd memory dimension step_size type1 seed iters regularization
+ * Usage:
+ *   out/gd [memory [type1 [dimension [step_size [seed [iters
+ *           [regularization [relaxation [safeguard_tolerance [max_aa_norm]]]]]]]]]]
  *
+ * Later arguments imply (and override) earlier ones; omit trailing args to
+ * use the compiled-in defaults.
  */
 int main(int argc, char **argv) {
   aa_int type1 = TYPE1, n = DIM, iters = ITERS, memory = MEM, seed = SEED;
@@ -76,22 +80,31 @@ int main(int argc, char **argv) {
   switch (argc - 1) {
   case 10:
     max_aa_norm = atof(argv[10]);
+    /* fallthrough */
   case 9:
     safeguard_tolerance = atof(argv[9]);
+    /* fallthrough */
   case 8:
     relaxation = atof(argv[8]);
+    /* fallthrough */
   case 7:
     regularization = atof(argv[7]);
+    /* fallthrough */
   case 6:
     iters = atoi(argv[6]);
+    /* fallthrough */
   case 5:
     seed = atoi(argv[5]);
+    /* fallthrough */
   case 4:
     neg_step_size = -atof(argv[4]);
+    /* fallthrough */
   case 3:
     n = atoi(argv[3]);
+    /* fallthrough */
   case 2:
     type1 = atoi(argv[2]);
+    /* fallthrough */
   case 1:
     memory = atoi(argv[1]);
     break;


### PR DESCRIPTION
## Summary
- \`examples/gd.c\`: the usage comment above \`main()\` listed arguments in the wrong order. Updated to match \`argv[1..10]\` parsing.
- \`examples/gd.c\`: annotate the switch's intentional fallthroughs so \`-Wimplicit-fallthrough\` on modern gcc/clang stays quiet.
- \`Makefile\`: \`make test\` now builds AND runs \`out/run_tests\`. Previously it only built, so a local \`make test\` gave a false pass — CI saved itself by running \`out/run_tests\` as a separate step.
- \`Makefile\`: \`LDLIBS ?= -lblas -llapack\` so users on MKL / OpenBLAS-only / renamed libs can override without editing the Makefile.

## Test plan
- [x] \`make clean && make && make test\` — builds and runs tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)