### PR TITLE
Expand test suite (C + Python) and fix dim=1 Python binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 out
 *.o
+*.so
 *.swp
 python/aapy.c
 python/build
 python/.*
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ purge: clean
 test: $(OUT)/run_tests
 
 $(OUT)/run_tests: test/run_tests.c $(OUT)/libaa.a
-	$(CC) $(CFLAGS) -o $@ $^ -lblas -llapack
+	$(CC) $(CFLAGS) -o $@ $^ -lblas -llapack -lm
 

--- a/python/aapy.pyx
+++ b/python/aapy.pyx
@@ -26,8 +26,10 @@ cdef class AndersonAccelerator(object):
         self._dim = dim
 
     def _validate(self, f, x):
-        f = np.squeeze(f)
-        x = np.squeeze(x)
+        # atleast_1d undoes np.squeeze's collapse of shape-(1,) to shape-() —
+        # without it, dim=1 users cannot pass a 1-D array through validation.
+        f = np.atleast_1d(np.squeeze(f))
+        x = np.atleast_1d(np.squeeze(x))
         if f.shape != (self._dim,) or x.shape != (self._dim,):
             raise ValueError("Incorrect input dimension")
         # aa_apply / aa_safeguard write through these pointers, so we must
@@ -58,4 +60,3 @@ cdef class AndersonAccelerator(object):
 
     def __dealloc__(self):
         aa_finish(self._wrk)
-

--- a/python/test_aa.py
+++ b/python/test_aa.py
@@ -1,0 +1,235 @@
+"""Tests for the aa Python bindings.
+
+Run from the ``python/`` directory after building the extension in place
+(``python setup.py build_ext --inplace``):
+
+    pytest test_aa.py
+"""
+
+import numpy as np
+import pytest
+
+import aa
+
+
+DIM = 20
+MEM = 5
+
+
+def _make_quadratic(dim, seed=0):
+    """Build a well-conditioned diagonal quadratic (1/2) x' Q x - q' x."""
+    rng = np.random.default_rng(seed)
+    eigs = np.linspace(0.1, 1.0, dim)
+    Q = np.diag(eigs)
+    q = rng.standard_normal(dim)
+    x_star = q / eigs
+    step = 1.0 / eigs.max()
+    return Q, q, x_star, step
+
+
+def _run_gd(Q, q, x0, step, steps, accelerator=None):
+    x = x0.copy()
+    x_prev = x.copy()
+    for i in range(steps):
+        if accelerator is not None and i > 0:
+            accelerator.apply(x, x_prev)
+        x_prev = x.copy()
+        x -= step * (Q @ x - q)
+        if accelerator is not None:
+            accelerator.safeguard(x, x_prev)
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_construct_defaults():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    assert isinstance(w, aa.AndersonAccelerator)
+
+
+def test_construct_type1():
+    w = aa.AndersonAccelerator(DIM, MEM, type1=True, regularization=1e-8)
+    assert isinstance(w, aa.AndersonAccelerator)
+
+
+def test_construct_all_kwargs():
+    w = aa.AndersonAccelerator(
+        DIM, MEM,
+        type1=True,
+        regularization=1e-8,
+        relaxation=0.9,
+        safeguard_factor=1.5,
+        max_weight_norm=1e4,
+        verbosity=0,
+    )
+    assert isinstance(w, aa.AndersonAccelerator)
+
+
+def test_construct_mem_zero():
+    """mem=0 should be accepted and behave as a no-op accelerator."""
+    w = aa.AndersonAccelerator(DIM, 0)
+    f = np.ones(DIM)
+    x = np.zeros(DIM)
+    f_before = f.copy()
+    w.apply(f, x)
+    np.testing.assert_array_equal(f, f_before)
+
+
+def test_construct_dim_one():
+    w = aa.AndersonAccelerator(1, MEM)
+    f = np.array([1.0])
+    x = np.array([0.0])
+    w.apply(f, x)
+    w.safeguard(f, x)
+
+
+def test_dim_one_accelerates():
+    """End-to-end exercise at dim=1 — the 1-D quadratic f(x) = 0.5 x^2 - x."""
+    w = aa.AndersonAccelerator(1, MEM, type1=True, regularization=1e-8)
+    x = np.array([5.0])
+    step = 1.0
+    for i in range(20):
+        if i > 0:
+            w.apply(x, x_prev)
+        x_prev = x.copy()
+        x -= step * (x - 1.0)
+        w.safeguard(x, x_prev)
+    assert np.isfinite(x).all()
+
+
+# ---------------------------------------------------------------------------
+# apply / safeguard basic semantics
+# ---------------------------------------------------------------------------
+
+
+def test_first_apply_is_noop():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    f = np.arange(DIM, dtype=np.float64)
+    x = np.zeros(DIM)
+    f_before = f.copy()
+    w.apply(f, x)
+    np.testing.assert_array_equal(f, f_before)
+
+
+def test_apply_returns_float():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    f = np.ones(DIM)
+    x = np.zeros(DIM)
+    result = w.apply(f, x)
+    assert isinstance(result, float)
+
+
+def test_safeguard_returns_int_like():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    f = np.ones(DIM)
+    x = np.zeros(DIM)
+    result = w.safeguard(f, x)
+    assert result in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_shape_rejected():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    with pytest.raises(ValueError):
+        w.apply(np.zeros(DIM + 1), np.zeros(DIM + 1))
+
+
+def test_mismatched_shape_rejected():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    with pytest.raises(ValueError):
+        w.apply(np.zeros(DIM), np.zeros(DIM - 1))
+
+
+def test_accepts_column_vector():
+    """A (dim, 1) array should be squeezed and accepted."""
+    w = aa.AndersonAccelerator(DIM, MEM)
+    f = np.zeros((DIM, 1))
+    x = np.zeros((DIM, 1))
+    w.apply(f, x)
+
+
+def test_accepts_row_vector():
+    w = aa.AndersonAccelerator(DIM, MEM)
+    f = np.zeros((1, DIM))
+    x = np.zeros((1, DIM))
+    w.apply(f, x)
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+
+def test_reset_restores_first_apply_noop():
+    """After reset(), the next apply should again be a no-op."""
+    Q, q, _, step = _make_quadratic(DIM)
+    w = aa.AndersonAccelerator(DIM, MEM)
+    rng = np.random.default_rng(0)
+    x0 = rng.standard_normal(DIM)
+    _run_gd(Q, q, x0, step, steps=20, accelerator=w)
+
+    w.reset()
+    f = np.arange(DIM, dtype=np.float64)
+    x = np.zeros(DIM)
+    f_before = f.copy()
+    w.apply(f, x)
+    np.testing.assert_array_equal(f, f_before)
+
+
+# ---------------------------------------------------------------------------
+# Integration: AA should accelerate plain gradient descent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("type1", [True, False])
+def test_aa_accelerates_gd(type1):
+    Q, q, x_star, step = _make_quadratic(DIM, seed=1)
+    rng = np.random.default_rng(2)
+    x0 = rng.standard_normal(DIM)
+
+    steps = 200
+    reg = 1e-8 if type1 else 1e-12
+    w = aa.AndersonAccelerator(DIM, MEM, type1=type1, regularization=reg)
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        x_aa = _run_gd(Q, q, x0, step, steps, accelerator=w)
+    x_plain = _run_gd(Q, q, x0, step, steps, accelerator=None)
+
+    err_aa = np.linalg.norm(x_aa - x_star)
+    err_plain = np.linalg.norm(x_plain - x_star)
+    assert err_aa < err_plain, (
+        f"AA did not improve on plain GD (aa={err_aa}, plain={err_plain})"
+    )
+    # Loose absolute target — mostly to catch catastrophic regressions.
+    assert err_aa < 1e-3
+
+
+def test_mem_capped_to_dim():
+    """mem > dim should be silently capped; apply still works."""
+    Q, q, x_star, step = _make_quadratic(DIM, seed=3)
+    rng = np.random.default_rng(4)
+    x0 = rng.standard_normal(DIM)
+
+    w = aa.AndersonAccelerator(DIM, DIM * 4, type1=True, regularization=1e-8)
+    with np.errstate(over="ignore", invalid="ignore"):
+        x = _run_gd(Q, q, x0, step, 200, accelerator=w)
+    assert np.all(np.isfinite(x))
+    assert np.linalg.norm(x - x_star) < 1e-2
+
+
+# ---------------------------------------------------------------------------
+# Many-workspace safety: aa_finish runs under __dealloc__.
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_destroy_many():
+    for _ in range(64):
+        w = aa.AndersonAccelerator(DIM, MEM)
+        del w

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -1,6 +1,16 @@
-/* Gradient descent (GD) on convex quadratic */
+/* Test suite for libaa.
+ *
+ * Two kinds of tests live here:
+ *   1. Integration: gradient descent on a random convex quadratic. These
+ *      exercise the full AA pipeline (BLAS calls, type-I/type-II, relaxed
+ *      and unrelaxed) and check convergence.
+ *   2. Unit / edge-case: targeted tests for aa_init, aa_reset, and the
+ *      boundary behaviors of aa_apply / aa_safeguard that are easy to
+ *      regress when touching the internals.
+ */
 #include "aa.h"
 #include "aa_blas.h"
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,7 +18,7 @@
 
 #include "minunit.h"
 
-/* default parameters */
+/* default parameters for the integration tests */
 #define SEED (1234)
 #define DIM (100)
 #define MEM (5)
@@ -23,7 +33,6 @@
 
 int tests_run = 0;
 
-/* duplicate these with underscore prefix */
 typedef struct _timer {
   struct timespec tic;
   struct timespec toc;
@@ -52,6 +61,18 @@ aa_float _tocq(_timer *t) {
 static aa_float rand_float(void) {
   return 2 * (((aa_float)rand()) / RAND_MAX) - 1;
 }
+
+static aa_float nrm2_vec(const aa_float *x, aa_int n) {
+  aa_float s = 0;
+  for (aa_int i = 0; i < n; i++) {
+    s += x[i] * x[i];
+  }
+  return sqrt(s);
+}
+
+/* =============================================================== */
+/*  Integration tests: GD on random convex quadratic.              */
+/* =============================================================== */
 
 static const char *gd(aa_int type1, aa_float relaxation) {
   aa_int n = DIM, iters = ITERS, memory = MEM, seed = SEED;
@@ -131,23 +152,223 @@ static const char *gd(aa_int type1, aa_float relaxation) {
   return 0;
 }
 
-static const char *gd_type1_relax1(void) {
-  return gd(1, 1.0);
+static const char *gd_type1_relax1(void)  { return gd(1, 1.0);  }
+static const char *gd_type1_relaxl1(void) { return gd(1, 0.98); }
+static const char *gd_type2_relax1(void)  { return gd(0, 1.0);  }
+static const char *gd_type2_relaxl1(void) { return gd(0, 0.98); }
+
+/* =============================================================== */
+/*  Unit / edge-case tests.                                        */
+/* =============================================================== */
+
+/* Run diagonal-Q gradient descent (optionally with AA) and return
+ * ||x|| after `iters` iterations. Qdiag must have strictly positive
+ * entries; step is a fixed scalar. Pass mem=0 to disable AA. */
+static aa_float diag_gd(const aa_float *Qdiag, aa_int n, aa_float step,
+                        aa_int mem, aa_int type1, aa_float relaxation,
+                        aa_int iters, unsigned seed) {
+  aa_float *x = (aa_float *)calloc(n, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
+  srand(seed);
+  for (aa_int i = 0; i < n; i++) {
+    x[i] = rand_float();
+  }
+  AaWork *a = aa_init(n, mem, type1, /*reg=*/1e-10, relaxation,
+                      /*safeguard=*/2.0, /*max_w=*/1e10, /*verbosity=*/0);
+  for (aa_int i = 0; i < iters; i++) {
+    if (i > 0) {
+      aa_apply(x, xprev, a);
+    }
+    memcpy(xprev, x, n * sizeof(aa_float));
+    for (aa_int j = 0; j < n; j++) {
+      x[j] -= step * Qdiag[j] * xprev[j];
+    }
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, n);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  return err;
 }
 
-static const char *gd_type1_relaxl1(void) {
-  return gd(1, 0.98);
+/* aa_init with mem=0 must not crash and both apply/safeguard must be
+ * no-ops (this path is what callers use to turn AA off dynamically). */
+static const char *test_mem_zero_is_noop(void) {
+  AaWork *a = aa_init(10, 0, 1, 1e-8, 1.0, 2.0, 1e10, 0);
+  mu_assert("aa_init(mem=0) returned NULL", a != NULL);
+
+  aa_float x[10], xprev[10];
+  for (int i = 0; i < 10; i++) {
+    x[i] = (aa_float)i * 0.1;
+    xprev[i] = x[i];
+  }
+  aa_float before = nrm2_vec(x, 10);
+
+  aa_float w = aa_apply(x, xprev, a);
+  mu_assert("aa_apply(mem=0) should return 0", w == 0);
+
+  aa_int r = aa_safeguard(x, xprev, a);
+  mu_assert("aa_safeguard(mem=0) should return 0", r == 0);
+
+  /* No-op means x is untouched. */
+  aa_float after = nrm2_vec(x, 10);
+  mu_assert("mem=0 apply/safeguard modified inputs", before == after);
+
+  aa_finish(a);
+  return 0;
 }
 
-static const char *gd_type2_relax1(void) {
-  return gd(0, 1.0);
+/* mem=1 is the smallest non-trivial memory — exercises the len=1
+ * path of the internal solve. */
+static const char *test_mem_one(void) {
+  aa_float Qdiag[10];
+  for (int i = 0; i < 10; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / 9.0; /* eigs in [0.1, 1] */
+  }
+  aa_float err = diag_gd(Qdiag, 10, /*step=*/1.0, /*mem=*/1, /*type1=*/1,
+                         /*relax=*/1.0, /*iters=*/500, /*seed=*/42);
+  mu_assert_less("mem=1 did not converge", err, 1e-4);
+  return 0;
 }
 
-static const char *gd_type2_relaxl1(void) {
-  return gd(0, 0.98);
+/* mem > dim is internally capped to dim (for rank stability). Must
+ * still produce a working accelerator. */
+static const char *test_mem_capped_to_dim(void) {
+  aa_float Qdiag[3] = {0.5, 1.0, 0.8};
+  aa_float err = diag_gd(Qdiag, 3, /*step=*/1.0, /*mem=*/20, /*type1=*/1,
+                         1.0, 400, 0);
+  mu_assert_less("mem>dim did not converge", err, 1e-8);
+  return 0;
 }
+
+/* dim=1 is a degenerate but valid use — make sure nothing assumes n>1. */
+static const char *test_dim_one(void) {
+  aa_float Qdiag[1] = {0.5};
+  aa_float err = diag_gd(Qdiag, 1, /*step=*/2.0, /*mem=*/3, /*type1=*/1,
+                         1.0, 50, 0);
+  mu_assert_less("dim=1 did not converge", err, 1e-10);
+  return 0;
+}
+
+/* aa_reset should restore the accelerator to first-iter behavior:
+ * running with reset + fresh inputs must produce the same trajectory
+ * as a brand-new workspace on the same inputs. */
+static const char *test_reset_matches_fresh_init(void) {
+  const aa_int n = 5;
+  aa_float Qdiag[5] = {0.2, 0.4, 0.6, 0.8, 1.0};
+  aa_float step = 1.0;
+  aa_float x0[5] = {1, 1, 1, 1, 1};
+
+  AaWork *a = aa_init(n, 3, 1, 1e-10, 1.0, 2.0, 1e10, 0);
+
+  /* First run: 20 iters from x0. */
+  aa_float x[5], xprev[5];
+  memcpy(x, x0, sizeof(x0));
+  for (int i = 0; i < 20; i++) {
+    if (i > 0) aa_apply(x, xprev, a);
+    memcpy(xprev, x, sizeof(x));
+    for (int j = 0; j < n; j++) x[j] -= step * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err_first = nrm2_vec(x, n);
+
+  /* Reset and run again from the same x0. */
+  aa_reset(a);
+  aa_float x2[5], xprev2[5];
+  memcpy(x2, x0, sizeof(x0));
+  for (int i = 0; i < 20; i++) {
+    if (i > 0) aa_apply(x2, xprev2, a);
+    memcpy(xprev2, x2, sizeof(x2));
+    for (int j = 0; j < n; j++) x2[j] -= step * Qdiag[j] * xprev2[j];
+    aa_safeguard(x2, xprev2, a);
+  }
+  aa_float err_after = nrm2_vec(x2, n);
+
+  aa_finish(a);
+
+  aa_float diff = fabs(err_first - err_after);
+  mu_assert_less("reset did not produce identical trajectory", diff, 1e-14);
+  return 0;
+}
+
+/* On a moderately-conditioned problem AA should comfortably beat plain GD
+ * at a fixed iteration budget. This is the headline claim of the library,
+ * so regress hard. */
+static const char *test_aa_accelerates_convergence(void) {
+  const aa_int n = 20;
+  aa_float Qdiag[20];
+  for (int i = 0; i < n; i++) {
+    Qdiag[i] = 0.01 + 0.99 * (aa_float)i / 19.0;
+  }
+  const aa_float step = 1.0; /* = 1 / max(Qdiag) */
+  const aa_int iters = 200;
+  const unsigned seed = 42;
+
+  aa_float err_no_aa = diag_gd(Qdiag, n, step, /*mem=*/0, 1, 1.0, iters, seed);
+  aa_float err_aa = diag_gd(Qdiag, n, step, /*mem=*/5, 1, 1.0, iters, seed);
+
+  printf("  no-AA err = %.3e, AA err = %.3e (ratio %.1fx)\n",
+         err_no_aa, err_aa, err_no_aa / err_aa);
+  /* Expect AA to beat plain GD by at least 10x on this problem. */
+  mu_assert("AA did not beat plain GD by 10x", err_aa * 10 < err_no_aa);
+  return 0;
+}
+
+/* Exercise the cyclic-buffer path: many iters on small mem means
+ * (iter-1) % mem wraps around thousands of times. A stale-index bug
+ * would produce wrong results or crash. */
+static const char *test_cyclic_buffer_long_run(void) {
+  const aa_int n = 5;
+  aa_float Qdiag[5] = {0.5, 0.6, 0.7, 0.8, 1.0};
+  aa_float err = diag_gd(Qdiag, n, /*step=*/1.0, /*mem=*/3, /*type1=*/1,
+                         1.0, /*iters=*/10000, /*seed=*/7);
+  mu_assert_less("long run did not converge", err, 1e-12);
+  return 0;
+}
+
+/* Type-II with mem=1 — symmetric of test_mem_one, verifies both
+ * types handle the len=1 solve path. */
+static const char *test_mem_one_type2(void) {
+  aa_float Qdiag[10];
+  for (int i = 0; i < 10; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / 9.0;
+  }
+  aa_float err = diag_gd(Qdiag, 10, /*step=*/1.0, /*mem=*/1, /*type1=*/0,
+                         /*relax=*/1.0, /*iters=*/500, /*seed=*/99);
+  mu_assert_less("type-II mem=1 did not converge", err, 1e-4);
+  return 0;
+}
+
+/* First-iteration behavior: aa_apply on iter 0 must only seed internal
+ * state and leave f untouched (return 0). This contract lets callers
+ * unconditionally call aa_apply without branching. */
+static const char *test_first_iter_is_noop_on_f(void) {
+  const aa_int n = 4;
+  AaWork *a = aa_init(n, 3, 1, 1e-8, 1.0, 2.0, 1e10, 0);
+  aa_float x[4] = {0.1, 0.2, 0.3, 0.4};
+  aa_float xprev[4] = {0, 0, 0, 0};
+  aa_float snapshot[4];
+  memcpy(snapshot, x, sizeof(x));
+
+  aa_float w = aa_apply(x, xprev, a);
+  mu_assert("first aa_apply should return weight norm 0", w == 0);
+  for (int i = 0; i < n; i++) {
+    mu_assert("first aa_apply must not modify f", x[i] == snapshot[i]);
+  }
+
+  /* Safeguard before any accepted AA step should also be a no-op. */
+  aa_int r = aa_safeguard(x, xprev, a);
+  mu_assert("aa_safeguard before any AA step should return 0", r == 0);
+
+  aa_finish(a);
+  return 0;
+}
+
+/* =============================================================== */
 
 static const char *all_tests(void) {
+  /* Integration tests — GD on random quadratic. */
   printf("type 1, relaxation 1.0\n");
   mu_run_test(gd_type1_relax1);
   printf("type 1, relaxation < 1.0\n");
@@ -156,6 +377,27 @@ static const char *all_tests(void) {
   mu_run_test(gd_type2_relax1);
   printf("type 2, relaxation < 1.0\n");
   mu_run_test(gd_type2_relaxl1);
+
+  /* Unit / edge-case tests. */
+  printf("unit: mem=0 is a no-op\n");
+  mu_run_test(test_mem_zero_is_noop);
+  printf("unit: mem=1 works\n");
+  mu_run_test(test_mem_one);
+  printf("unit: mem=1 works (type-II)\n");
+  mu_run_test(test_mem_one_type2);
+  printf("unit: mem > dim is capped\n");
+  mu_run_test(test_mem_capped_to_dim);
+  printf("unit: dim=1 works\n");
+  mu_run_test(test_dim_one);
+  printf("unit: first aa_apply is a no-op on f\n");
+  mu_run_test(test_first_iter_is_noop_on_f);
+  printf("unit: aa_reset matches a fresh aa_init\n");
+  mu_run_test(test_reset_matches_fresh_init);
+  printf("unit: cyclic buffer survives a long run\n");
+  mu_run_test(test_cyclic_buffer_long_run);
+  printf("unit: AA accelerates convergence vs plain GD\n");
+  mu_run_test(test_aa_accelerates_convergence);
+
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- Expands `test/run_tests.c` from 4 integration tests to 13: keeps the original gradient-descent tests and adds unit/edge-case coverage (mem=0 no-op, mem=1 for type-I and type-II, mem > dim capping, dim=1, first-apply no-op, `aa_reset` equivalence to a fresh init, long cyclic-buffer run, AA-vs-plain-GD convergence check).
- Adds a `pytest` suite in `python/test_aa.py` (18 tests): construction with every kwarg, input validation (shape, row/column vectors), reset semantics, integration against plain GD for both type-I and type-II, mem > dim handling, workspace create/destroy cycling.
- Fixes a latent binding bug surfaced by the new `dim=1` test: `np.squeeze` collapses a shape-`(1,)` array to shape `()`, which the validator then rejected. `AndersonAccelerator(dim=1, …)` was effectively unusable from Python even though the C core supports it. Wrap the squeezed array in `np.atleast_1d`.
- Ignore `*.so` and `.pytest_cache` build artifacts.

## Test plan
- [x] `make clean && make test && out/run_tests` — all 13 C tests pass
- [x] `cd python && python setup.py build_ext --inplace && pytest test_aa.py` — all 18 Python tests pass
- [ ] CI green (will rely on existing workflows; wiring of the new `test_aa.py` into CI is not included here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)