### PR TITLE
Support PROFILING on Windows

### DIFF
--- a/.github/workflows/windows-c.yml
+++ b/.github/workflows/windows-c.yml
@@ -1,0 +1,48 @@
+name: Windows C
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up OpenBLAS (Windows)
+        shell: pwsh
+        run: |
+          $version = "0.3.27"
+          $url = "https://github.com/OpenMathLib/OpenBLAS/releases/download/v$version/OpenBLAS-$version-x64.zip"
+          $staging = "$env:GITHUB_WORKSPACE\openblas-staging"
+          Invoke-WebRequest -Uri $url -OutFile openblas.zip
+          Expand-Archive -Path openblas.zip -DestinationPath $staging
+          $libFile = Get-ChildItem $staging -Recurse -Filter libopenblas.lib | Select-Object -First 1
+          if (-not $libFile) { throw "libopenblas.lib not found under $staging" }
+          $root = ($libFile.Directory.Parent.FullName) -replace '\\','/'
+          "OPENBLAS_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Add bin directory to PATH so DLL is found at runtime
+          "$root/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build C Library
+        shell: cmd
+        run: |
+          mkdir out
+          cl /O2 /Iinclude /DPROFILING=1 tests\c\run_tests.c src\aa.c /I%OPENBLAS_ROOT%\include /link /LIBPATH:%OPENBLAS_ROOT%\lib libopenblas.lib /out:out\run_tests.exe
+          cl /O2 /Iinclude /DPROFILING=1 tests\c\gd.c src\aa.c /I%OPENBLAS_ROOT%\include /link /LIBPATH:%OPENBLAS_ROOT%\lib libopenblas.lib /out:out\gd.exe
+
+      - name: Run C Tests
+        shell: cmd
+        run: |
+          out\run_tests.exe
+
+      - name: Run GD convergence tests
+        shell: bash
+        run: |
+          export GD=out/gd.exe
+          bash tests/c/check_gd_convergence.sh

--- a/src/aa.c
+++ b/src/aa.c
@@ -36,6 +36,24 @@
   tic(&__t);
 #define TIME_TOC toc(__func__, &__t);
 
+#ifdef _WIN32
+#include <windows.h>
+typedef struct timer {
+  LARGE_INTEGER tic;
+  LARGE_INTEGER toc;
+} timer;
+
+void tic(timer *t) {
+  QueryPerformanceCounter(&t->tic);
+}
+
+aa_float tocq(timer *t) {
+  LARGE_INTEGER freq;
+  QueryPerformanceFrequency(&freq);
+  QueryPerformanceCounter(&t->toc);
+  return (aa_float)(t->toc.QuadPart - t->tic.QuadPart) / (aa_float)freq.QuadPart * 1e3;
+}
+#else
 #include <time.h>
 typedef struct timer {
   struct timespec tic;
@@ -60,6 +78,7 @@ aa_float tocq(timer *t) {
   }
   return (aa_float)temp.tv_sec * 1e3 + (aa_float)temp.tv_nsec / 1e6;
 }
+#endif
 
 aa_float toc(const char *str, timer *t) {
   aa_float time = tocq(t);

--- a/tests/c/gd.c
+++ b/tests/c/gd.c
@@ -21,6 +21,24 @@
 #define VERBOSITY (1)
 
 
+#ifdef _WIN32
+#include <windows.h>
+typedef struct _timer {
+  LARGE_INTEGER tic;
+  LARGE_INTEGER toc;
+} _timer;
+
+void _tic(_timer *t) {
+  QueryPerformanceCounter(&t->tic);
+}
+
+aa_float _tocq(_timer *t) {
+  LARGE_INTEGER freq;
+  QueryPerformanceFrequency(&freq);
+  QueryPerformanceCounter(&t->toc);
+  return (aa_float)(t->toc.QuadPart - t->tic.QuadPart) / (aa_float)freq.QuadPart * 1e3;
+}
+#else
 /* duplicate these with underscore prefix */
 typedef struct _timer {
   struct timespec tic;
@@ -45,6 +63,7 @@ aa_float _tocq(_timer *t) {
   }
   return (aa_float)temp.tv_sec * 1e3 + (aa_float)temp.tv_nsec / 1e6;
 }
+#endif
 
 /* uniform random number in [-1,1] */
 static aa_float rand_float(void) {

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -33,6 +33,24 @@
 
 int tests_run = 0;
 
+#ifdef _WIN32
+#include <windows.h>
+typedef struct _timer {
+  LARGE_INTEGER tic;
+  LARGE_INTEGER toc;
+} _timer;
+
+void _tic(_timer *t) {
+  QueryPerformanceCounter(&t->tic);
+}
+
+aa_float _tocq(_timer *t) {
+  LARGE_INTEGER freq;
+  QueryPerformanceFrequency(&freq);
+  QueryPerformanceCounter(&t->toc);
+  return (aa_float)(t->toc.QuadPart - t->tic.QuadPart) / (aa_float)freq.QuadPart * 1e3;
+}
+#else
 typedef struct _timer {
   struct timespec tic;
   struct timespec toc;
@@ -56,6 +74,7 @@ aa_float _tocq(_timer *t) {
   }
   return (aa_float)temp.tv_sec * 1e3 + (aa_float)temp.tv_nsec / 1e6;
 }
+#endif
 
 /* uniform random number in [-1,1] */
 static aa_float rand_float(void) {


### PR DESCRIPTION
Wraps the C timing code with `#ifdef _WIN32` and implements `QueryPerformanceCounter` for MSVC compatibility when `-DPROFILING=1` is set.