### PR TITLE
Rename PyPI dist to anderson-acceleration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi
-      url: https://pypi.org/p/aa
+      url: https://pypi.org/p/anderson-acceleration
     permissions:
       id-token: write
     steps:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ for i = 0, 1, 2, ...
 ### Python
 
 ```bash
-pip install aa
+pip install anderson-acceleration
 ```
 
 The wheel bundles an optimized BLAS/LAPACK (Apple's Accelerate on macOS,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=77", "wheel", "Cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "aa"
+name = "anderson-acceleration"
 version = "0.0.1"
 description = "Anderson acceleration for fixed-point iterations"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
## Summary

The short name `aa` is already registered on PyPI, so we can't publish under it. Rename the PyPI **distribution** to `anderson-acceleration` (more discoverable anyway — matches the library's actual subject). The Python **import** name stays `aa`, same pattern as `scikit-learn` → `import sklearn`.

Changes:
- `pyproject.toml:8` — `name = "aa"` → `"anderson-acceleration"`
- `publish.yml:106` — environment URL points to the new project slug
- `README.md:45` — install command updated

GitHub repo, `import aa`, and the Cython extension name all stay as-is.

## Test plan

- [ ] PR CI green (no behavioral changes; this is a pure metadata rename)
- [ ] Before tagging `v0.0.1`: register pending publisher for `anderson-acceleration` at https://pypi.org/manage/account/publishing/ (owner `cvxgrp`, repo `aa`, workflow `publish.yml`, environment `pypi`)
- [ ] Create GitHub environment `pypi` in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)