### PR TITLE
fix: clear stale safeguard state on reset

### DIFF
--- a/src/aa.c
+++ b/src/aa.c
@@ -494,7 +494,7 @@ void aa_finish(AaWork *a) {
 }
 
 void aa_reset(AaWork *a) {
-  /* to reset we simply set a->iter = 0 */
+  /* reset to the same logical state as a freshly calloc'd workspace */
   if (!a) {
     return;
   }
@@ -502,4 +502,48 @@ void aa_reset(AaWork *a) {
     printf("AA reset.\n");
   }
   a->iter = 0;
+  a->success = 0;
+  a->norm_g = 0;
+  if (a->x) {
+    memset(a->x, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->f) {
+    memset(a->f, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->g) {
+    memset(a->g, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->g_prev) {
+    memset(a->g_prev, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->y) {
+    memset(a->y, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->s) {
+    memset(a->s, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->d) {
+    memset(a->d, 0, sizeof(aa_float) * a->dim);
+  }
+  if (a->Y) {
+    memset(a->Y, 0, sizeof(aa_float) * a->dim * a->mem);
+  }
+  if (a->S) {
+    memset(a->S, 0, sizeof(aa_float) * a->dim * a->mem);
+  }
+  if (a->D) {
+    memset(a->D, 0, sizeof(aa_float) * a->dim * a->mem);
+  }
+  if (a->M) {
+    memset(a->M, 0, sizeof(aa_float) * a->mem * a->mem);
+  }
+  if (a->work) {
+    memset(a->work, 0, sizeof(aa_float) * MAX(a->mem, a->dim));
+  }
+  if (a->ipiv) {
+    memset(a->ipiv, 0, sizeof(blas_int) * a->mem);
+  }
+  if (a->x_work) {
+    memset(a->x_work, 0, sizeof(aa_float) * a->dim);
+  }
 }

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -311,6 +311,39 @@ static const char *test_reset_matches_fresh_init(void) {
   return 0;
 }
 
+/* reset must clear any "last AA step succeeded" state so a subsequent
+ * safeguard call cannot roll inputs back to pre-reset iterates. */
+static const char *test_reset_clears_stale_safeguard_state(void) {
+  AaWork *a = aa_init(2, 2, 1, 1e-8, 1.0, 1.0, 1e10, 0);
+  aa_float x[2] = {1.0, 1.0};
+  aa_float f[2] = {0.5, 0.5};
+
+  aa_apply(f, x, a);
+
+  memcpy(x, f, sizeof(x));
+  f[0] *= 0.5;
+  f[1] *= 0.5;
+  aa_apply(f, x, a);
+
+  memcpy(x, f, sizeof(x));
+  f[0] *= 0.5;
+  f[1] *= 0.5;
+  aa_float aa_norm = aa_apply(f, x, a);
+  mu_assert("expected a successful AA step before reset", aa_norm > 0);
+
+  aa_reset(a);
+
+  aa_float f_new[2] = {3.0, 4.0};
+  aa_float x_new[2] = {1.0, 2.0};
+  aa_int safeguard = aa_safeguard(f_new, x_new, a);
+  mu_assert("safeguard after reset should be a no-op", safeguard == 0);
+  mu_assert("reset should prevent stale rollback of f_new", f_new[0] == 3.0);
+  mu_assert("reset should prevent stale rollback of x_new", x_new[0] == 1.0);
+
+  aa_finish(a);
+  return 0;
+}
+
 /* On a moderately-conditioned problem AA should comfortably beat plain GD
  * at a fixed iteration budget. This is the headline claim of the library,
  * so regress hard. */
@@ -412,6 +445,8 @@ static const char *all_tests(void) {
   mu_run_test(test_first_iter_is_noop_on_f);
   printf("unit: aa_reset matches a fresh aa_init\n");
   mu_run_test(test_reset_matches_fresh_init);
+  printf("unit: aa_reset clears stale safeguard state\n");
+  mu_run_test(test_reset_clears_stale_safeguard_state);
   printf("unit: cyclic buffer survives a long run\n");
   mu_run_test(test_cyclic_buffer_long_run);
   printf("unit: AA accelerates convergence vs plain GD\n");

--- a/tests/python/test_aa.py
+++ b/tests/python/test_aa.py
@@ -281,3 +281,29 @@ def test_safeguard_rejection_restores_arrays():
     # Safeguard restores the last known good f and x.
     assert not np.allclose(f_new, [100.0, 100.0])
     assert not np.allclose(x_new, [-100.0, -100.0])
+
+
+def test_reset_clears_stale_safeguard_state():
+    accel = aa.AndersonAccelerator(dim=2, mem=2, safeguard_factor=1.0)
+
+    x = np.array([1.0, 1.0])
+    f = 0.5 * x
+    accel.apply(f, x)
+
+    x = f.copy()
+    f = 0.5 * x
+    accel.apply(f, x)
+
+    x = f.copy()
+    f = 0.5 * x
+    assert accel.apply(f, x) > 0
+
+    accel.reset()
+
+    f_new = np.array([3.0, 4.0])
+    x_new = np.array([1.0, 2.0])
+    accepted = accel.safeguard(f_new, x_new)
+
+    assert accepted == 0
+    np.testing.assert_array_equal(f_new, [3.0, 4.0])
+    np.testing.assert_array_equal(x_new, [1.0, 2.0])


### PR DESCRIPTION
## Summary
- make `aa_reset()` clear the live safeguard state instead of only rewinding `iter`
- add C and Python regressions for the stale-rollback-after-reset bug

## Testing
- make test
- python -m pytest -q tests/python/test_aa.py