### PR TITLE
fix: add legacy setup metadata for editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ To change these, compile with:
 ## Building the Python bindings from source
 
 ```bash
+python -m pip install --upgrade pip
 pip install cython numpy
 pip install -e .
 python python/example.py
@@ -216,6 +217,10 @@ python python/example.py
 
 The bindings `#include` the C source directly, so no separate library is
 needed.
+
+Editable installs are expected to use a recent `pip` that supports modern
+PEP 517/660 builds. If your environment falls back to `setup.py develop`,
+upgrade `pip` first and install inside a virtual environment.
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -218,10 +218,6 @@ python python/example.py
 The bindings `#include` the C source directly, so no separate library is
 needed.
 
-Editable installs are expected to use a recent `pip` that supports modern
-PEP 517/660 builds. If your environment falls back to `setup.py develop`,
-upgrade `pip` first and install inside a virtual environment.
-
 ## Citing
 
 If you use this library in academic work, please cite:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ requires = ["setuptools>=77", "wheel", "Cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
+# Keep these in sync with setup.py, which duplicates them for legacy
+# setuptools/editable-install code paths.
 name = "anderson-acceleration"
 version = "0.0.1"
 description = "Anderson acceleration for fixed-point iterations"

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,13 @@ import platform
 from setuptools import Extension, setup
 from Cython.Build import cythonize
 
+# Keep enough metadata here for legacy setuptools code paths (`setup.py
+# develop`, `setup.py egg_info`, older pip editable installs) to avoid
+# synthesizing an `UNKNOWN` distribution. The canonical project metadata
+# still lives in pyproject.toml.
+NAME = "anderson-acceleration"
+VERSION = "0.0.1"
+
 include_dirs = ["include"]
 library_dirs = []
 libraries = []
@@ -51,4 +58,9 @@ aa_extension = Extension(
     extra_link_args=extra_link_args,
 )
 
-setup(ext_modules=cythonize([aa_extension], language_level=3))
+setup(
+    name=NAME,
+    version=VERSION,
+    install_requires=["numpy"],
+    ext_modules=cythonize([aa_extension], language_level=3),
+)


### PR DESCRIPTION
## Summary
- give `setup.py` enough metadata for legacy setuptools code paths to stop producing an `UNKNOWN` distribution
- document the expectation that editable installs use a modern `pip` inside a virtual environment

## Testing
- python setup.py --name --version
- python -m pytest -q tests/python/test_aa.py tests/python/test_wheel.py