### PR TITLE
fix: validate constructor arguments early

### DIFF
--- a/python/aapy.pyx
+++ b/python/aapy.pyx
@@ -19,6 +19,18 @@ cdef class AndersonAccelerator(object):
     def __cinit__(self, dim, mem, type1=False, regularization=1e-12,
                   relaxation=1.0, safeguard_factor=1.0, max_weight_norm=1e6,
                   verbosity=0):
+        if dim <= 0:
+            raise ValueError("dim must be positive")
+        if mem < 0:
+            raise ValueError("mem must be non-negative")
+        if regularization < 0:
+            raise ValueError("regularization must be non-negative")
+        if relaxation < 0 or relaxation > 2:
+            raise ValueError("relaxation must be in [0, 2]")
+        if safeguard_factor < 0:
+            raise ValueError("safeguard_factor must be non-negative")
+        if max_weight_norm <= 0:
+            raise ValueError("max_weight_norm must be positive")
         self._wrk = aa_init(dim, mem, type1, regularization, relaxation,
                             safeguard_factor, max_weight_norm, verbosity)
         if self._wrk is NULL:

--- a/src/aa.c
+++ b/src/aa.c
@@ -330,7 +330,7 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
                 aa_float max_weight_norm, aa_int verbosity) {
   TIME_TIC
   AaWork *a;
-  if (dim < 0 || mem < 0 || regularization < 0 ||
+  if (dim <= 0 || mem < 0 || regularization < 0 ||
       relaxation < 0 || relaxation > 2 ||
       safeguard_factor < 0 || max_weight_norm <= 0) {
     printf("Invalid AA parameters.\n");

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -238,6 +238,12 @@ static const char *test_mem_zero_is_noop(void) {
   return 0;
 }
 
+static const char *test_dim_zero_rejected(void) {
+  AaWork *a = aa_init(0, 1, 1, 1e-8, 1.0, 2.0, 1e10, 0);
+  mu_assert("aa_init(dim=0) should return NULL", a == NULL);
+  return 0;
+}
+
 /* mem=1 is the smallest non-trivial memory — exercises the len=1
  * path of the internal solve. */
 static const char *test_mem_one(void) {
@@ -400,6 +406,8 @@ static const char *all_tests(void) {
   /* Unit / edge-case tests. */
   printf("unit: mem=0 is a no-op\n");
   mu_run_test(test_mem_zero_is_noop);
+  printf("unit: dim=0 is rejected\n");
+  mu_run_test(test_dim_zero_rejected);
   printf("unit: mem=1 works\n");
   mu_run_test(test_mem_one);
   printf("unit: mem=1 works (type-II)\n");

--- a/tests/python/test_aa.py
+++ b/tests/python/test_aa.py
@@ -86,6 +86,22 @@ def test_construct_dim_one():
     w.safeguard(f, x)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (dict(dim=0, mem=MEM), "dim must be positive"),
+        (dict(dim=DIM, mem=-1), "mem must be non-negative"),
+        (dict(dim=DIM, mem=MEM, regularization=-1.0), "regularization must be non-negative"),
+        (dict(dim=DIM, mem=MEM, relaxation=3.0), "relaxation must be in \\[0, 2\\]"),
+        (dict(dim=DIM, mem=MEM, safeguard_factor=-1.0), "safeguard_factor must be non-negative"),
+        (dict(dim=DIM, mem=MEM, max_weight_norm=0.0), "max_weight_norm must be positive"),
+    ],
+)
+def test_construct_invalid_args_raise_value_error(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        aa.AndersonAccelerator(**kwargs)
+
+
 def test_dim_one_accelerates():
     """End-to-end exercise at dim=1 — the 1-D quadratic f(x) = 0.5 x^2 - x."""
     w = aa.AndersonAccelerator(1, MEM, type1=True, regularization=1e-8)


### PR DESCRIPTION
## Summary
- reject `dim <= 0` in the C API
- raise `ValueError` from the Python constructor for invalid user arguments instead of surfacing `MemoryError`
- add C and Python coverage for the invalid-argument cases

## Testing
- make test
- python -m pytest -q tests/python/test_aa.py