### PR TITLE
test: enforce documented safeguard return codes

### DIFF
--- a/tests/python/test_aa.py
+++ b/tests/python/test_aa.py
@@ -127,7 +127,7 @@ def test_safeguard_returns_int_like():
     f = np.ones(DIM)
     x = np.zeros(DIM)
     result = w.safeguard(f, x)
-    assert result in (0, 1)
+    assert result in (0, -1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update the Python test suite to accept the documented `safeguard()` return codes (`0` and `-1`) instead of the impossible value `1`

## Testing
- python -m pytest -q tests/python/test_aa.py