### PR TITLE
chore: ignore local venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 wheelhouse/
 *.egg-info/
 .venv/
+venv/


### PR DESCRIPTION
## Summary
- ignore the common `venv/` directory alongside the already-ignored `.venv/`

## Testing
- git status --short