### PR TITLE
build: remove packaging warning noise

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include LICENSE.txt
 include setup.py
 include python/aapy.pyx
 recursive-include include *.h
-recursive-include src *.c *.h
+recursive-include src *.c
 recursive-include tests *.py *.c *.h *.sh

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,5 @@ aa_extension = Extension(
 setup(
     name=NAME,
     version=VERSION,
-    install_requires=["numpy"],
     ext_modules=cythonize([aa_extension], language_level=3),
 )


### PR DESCRIPTION
## Summary
- drop the redundant legacy-only `install_requires` from `setup.py` so setuptools stops warning that pyproject metadata overwrote it
- stop globbing for nonexistent `src/*.h` files in `MANIFEST.in`

## Testing
- python3 setup.py --name --version
- python3 -m build --sdist
- python3 -m build --wheel