### PR TITLE
tests: add latency and accuracy benchmark suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,5 @@ jobs:
         run: python -m pip install -e .
       - name: Run pytest suite
         run: pytest -v tests/python/test_aa.py
+      - name: Run Python benchmarks
+        run: python tests/python/bench.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # MAKEFILE for aa
-.PHONY: default clean purge test
+.PHONY: default clean purge test bench
 
 OBJECTS = src/aa.o
 
@@ -19,7 +19,7 @@ OUT = out
 ARCHIVE = ar -rv
 RANLIB = ranlib
 
-default: $(OUT)/libaa.a $(OUT)/gd
+default: $(OUT)/libaa.a $(OUT)/gd $(OUT)/bench
 
 %.o : src/%.c
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -34,14 +34,21 @@ $(OUT)/libaa.a: $(OBJECTS)
 $(OUT)/gd: tests/c/gd.c $(OUT)/libaa.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
+$(OUT)/bench: tests/c/bench.c $(OUT)/libaa.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 clean:
 	@rm -rf $(OBJECTS)
 purge: clean
 	@rm -rf $(OUT)
 
-test: $(OUT)/run_tests $(OUT)/gd
+test: $(OUT)/run_tests $(OUT)/gd $(OUT)/bench
 	$(OUT)/run_tests
 	tests/c/check_gd_convergence.sh
+	$(OUT)/bench
+
+bench: $(OUT)/bench
+	$(OUT)/bench
 
 $(OUT)/run_tests: tests/c/run_tests.c $(OUT)/libaa.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)

--- a/tests/c/bench.c
+++ b/tests/c/bench.c
@@ -1,0 +1,342 @@
+/* Latency and accuracy benchmarks for libaa.
+ *
+ * Prints a table of per-configuration numbers every time `make test` runs,
+ * so CI logs carry a baseline we can eyeball for regressions. Wall times
+ * on CI runners jitter from run to run — the counters (applies, aa_rej,
+ * sg_rej) and final_err are the stable regression signals.
+ *
+ * Problem: gradient descent on a diagonal convex quadratic
+ *   (1/2) x^T Q x,  Q = diag(eigs),  eigs uniform in [1/cond, 1],
+ *   F(x) = x - step * (Qdiag .* x),  step = 1/max(eigs) = 1,
+ *   optimum at x = 0,  initial x_i = sin((i+1) * 0.1).
+ *
+ * The map is intentionally cheap (O(dim)) so AA overhead shows up as a
+ * meaningful fraction of wall time.
+ *
+ * Sweeps:
+ *   scan:dim        fixed mem, varies dim        (shows AA scaling in dim)
+ *   scan:mem        fixed dim, varies mem        (shows set_m/gemv in mem)
+ *   scan:type       type-I vs type-II, same cfg
+ *   scan:cond       varies conditioning          (convergence pressure)
+ *   relaxation      relaxation != 1.0 path
+ *   near-optimum    long run on an easy problem — after ~20 iters the
+ *                   iterates are at machine precision, so S,Y columns
+ *                   are denormal noise and M = Y^T Y is catastrophically
+ *                   ill-conditioned. Exercises aa_apply's gesv-failure
+ *                   path and the aa_reset fallback. Regressions in the
+ *                   numerics show up here as blown-up final_err, NaNs,
+ *                   or a change in the aa_rej/sg_rej counts.
+ *   noisy-floor     deterministic but iteration-dependent perturbation
+ *                   injected into F(x). Iterates never fully converge —
+ *                   they bounce within a ball of radius ~ noise_scale.
+ *                   This is the *realistic* near-optimum regime (the
+ *                   ~1e-6 iterate-difference world that real solvers
+ *                   live in: stochastic gradients, approximate prox
+ *                   operators, fixed tolerance on inner solves). Gram
+ *                   matrix M is ill-conditioned but not denormal; it's
+ *                   the hardest case for AA numerics because the signal
+ *                   is O(noise_scale) and the noise is O(eps·|x|).
+ *
+ * Columns:
+ *   final_err  final ||x|| (optimum is 0); accuracy signal
+ *   applies    # successful aa_apply calls (returned positive weight norm)
+ *   aa_rej     # aa_apply calls that were rejected (returned <= 0)
+ *   sg_rej     # aa_safeguard calls that rolled the step back
+ *   total_ms   total wall-clock for the whole run (map + AA)
+ *   us/apply   average microseconds per aa_apply + aa_safeguard call
+ *   aa%        fraction of wall time spent inside AA
+ */
+#include "aa.h"
+#include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+typedef struct _timer {
+  LARGE_INTEGER tic;
+  LARGE_INTEGER toc;
+} _timer;
+
+static void _tic(_timer *t) {
+  QueryPerformanceCounter(&t->tic);
+}
+
+static aa_float _tocq(_timer *t) {
+  LARGE_INTEGER freq;
+  QueryPerformanceFrequency(&freq);
+  QueryPerformanceCounter(&t->toc);
+  return (aa_float)(t->toc.QuadPart - t->tic.QuadPart) /
+         (aa_float)freq.QuadPart * 1e3;
+}
+#else
+typedef struct _timer {
+  struct timespec tic;
+  struct timespec toc;
+} _timer;
+
+static void _tic(_timer *t) {
+  clock_gettime(CLOCK_MONOTONIC, &t->tic);
+}
+
+static aa_float _tocq(_timer *t) {
+  struct timespec temp;
+  clock_gettime(CLOCK_MONOTONIC, &t->toc);
+  if ((t->toc.tv_nsec - t->tic.tv_nsec) < 0) {
+    temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec - 1;
+    temp.tv_nsec = 1e9 + t->toc.tv_nsec - t->tic.tv_nsec;
+  } else {
+    temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec;
+    temp.tv_nsec = t->toc.tv_nsec - t->tic.tv_nsec;
+  }
+  return (aa_float)temp.tv_sec * 1e3 + (aa_float)temp.tv_nsec / 1e6;
+}
+#endif
+
+typedef struct {
+  const char *label;
+  aa_int dim;
+  aa_int mem;
+  aa_int type1;
+  aa_float relaxation;
+  aa_float cond;         /* condition number; min eig = 1/cond, max = 1.0 */
+  aa_int iters;
+  aa_float regularization;
+  aa_float noise_scale;  /* 0 = clean; else iter-dependent perturbation
+                          * added to F(x), simulating a noisy fixed-point
+                          * map. Iterates settle in a ball of ~noise_scale. */
+} bench_cfg;
+
+static aa_float nrm2(const aa_float *x, aa_int n) {
+  aa_float s = 0;
+  for (aa_int i = 0; i < n; i++) s += x[i] * x[i];
+  return sqrt(s);
+}
+
+static void run_one(bench_cfg cfg) {
+  aa_int n = cfg.dim;
+  aa_float *x = (aa_float *)malloc(sizeof(aa_float) * n);
+  aa_float *xprev = (aa_float *)malloc(sizeof(aa_float) * n);
+  aa_float *Qdiag = (aa_float *)malloc(sizeof(aa_float) * n);
+
+  /* Reproducible problem setup — no RNG state, identical every run. */
+  aa_float eig_lo = 1.0 / cfg.cond;
+  for (aa_int i = 0; i < n; i++) {
+    aa_float t = (n == 1) ? 0 : (aa_float)i / (aa_float)(n - 1);
+    Qdiag[i] = eig_lo + (1.0 - eig_lo) * t;
+    x[i] = sin((aa_float)(i + 1) * 0.1); /* reproducible, nonzero */
+  }
+  aa_float step = 1.0; /* = 1 / max(Qdiag) */
+
+  AaWork *a = aa_init(n, cfg.mem, cfg.type1, cfg.regularization,
+                      cfg.relaxation, /*safeguard_factor=*/2.0,
+                      /*max_weight_norm=*/1e10, /*verbosity=*/0);
+  if (!a) {
+    printf("%-20s | aa_init failed\n", cfg.label);
+    free(x); free(xprev); free(Qdiag);
+    return;
+  }
+
+  _timer total_timer, aa_timer;
+  aa_float aa_ms = 0.0;
+  aa_int applies = 0, aa_rej = 0, sg_rej = 0;
+
+  _tic(&total_timer);
+  for (aa_int i = 0; i < cfg.iters; i++) {
+    if (i > 0) {
+      _tic(&aa_timer);
+      aa_float w = aa_apply(x, xprev, a);
+      aa_ms += _tocq(&aa_timer);
+      if (w > 0) applies++;
+      else       aa_rej++;
+    }
+    memcpy(xprev, x, sizeof(aa_float) * n);
+    /* x = F(xprev): diagonal GD, optionally with iter-dependent noise
+     * scaled to ~noise_scale so iterates keep moving by O(noise_scale). */
+    if (cfg.noise_scale > 0) {
+      for (aa_int j = 0; j < n; j++) {
+        aa_float w = sin((aa_float)(i * 131 + j + 1) * 0.07);
+        x[j] -= step * Qdiag[j] * xprev[j];
+        x[j] += cfg.noise_scale * w;
+      }
+    } else {
+      for (aa_int j = 0; j < n; j++) {
+        x[j] -= step * Qdiag[j] * xprev[j];
+      }
+    }
+    _tic(&aa_timer);
+    aa_int sg = aa_safeguard(x, xprev, a);
+    aa_ms += _tocq(&aa_timer);
+    if (sg != 0) sg_rej++;
+  }
+  aa_float total_ms = _tocq(&total_timer);
+  aa_float err = nrm2(x, n);
+
+  aa_int aa_calls = applies + aa_rej;
+  aa_float us_per_apply = (aa_calls > 0) ? (aa_ms * 1e3 / aa_calls) : 0.0;
+  aa_float aa_frac = (total_ms > 0) ? (aa_ms / total_ms) : 0.0;
+
+  printf("%-20s | %6d %4d   %-2s  %4.2f | %6d | %10.3e | %6d %5d %5d | %9.2f | %9.2f | %5.1f%%\n",
+         cfg.label, (int)cfg.dim, (int)cfg.mem,
+         cfg.type1 ? "I" : "II", (double)cfg.relaxation, (int)cfg.iters,
+         err, (int)applies, (int)aa_rej, (int)sg_rej,
+         total_ms, us_per_apply, aa_frac * 100.0);
+
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  free(Qdiag);
+}
+
+static void print_header(const char *section) {
+  printf("\n-- %s --\n", section);
+  printf("%-20s | %6s %4s %4s %4s | %6s | %10s | %6s %5s %5s | %9s | %9s | %6s\n",
+         "label", "dim", "mem", "type", "rlx", "iters",
+         "final_err", "applied", "a_rej", "s_rej",
+         "total_ms", "us/call", "aa%");
+  printf("------------------------------------------------------------------"
+         "-------------------------------------------------------------------"
+         "---\n");
+}
+
+int main(void) {
+  /* Warmup: first BLAS call pays dynamic-linker / kernel fault costs that
+   * would otherwise get charged to whichever config runs first. Throw away
+   * a small run to amortize that. */
+  {
+    const aa_int wd = 50, wm = 5, wi = 50;
+    aa_float *x = (aa_float *)malloc(sizeof(aa_float) * wd);
+    aa_float *xprev = (aa_float *)malloc(sizeof(aa_float) * wd);
+    for (aa_int i = 0; i < wd; i++) { x[i] = 1.0; xprev[i] = 0.0; }
+    AaWork *a = aa_init(wd, wm, 0, 1e-12, 1.0, 2.0, 1e10, 0);
+    for (aa_int i = 0; i < wi; i++) {
+      if (i > 0) aa_apply(x, xprev, a);
+      memcpy(xprev, x, sizeof(aa_float) * wd);
+      for (aa_int j = 0; j < wd; j++) x[j] *= 0.9;
+      aa_safeguard(x, xprev, a);
+    }
+    aa_finish(a);
+    free(x); free(xprev);
+  }
+
+  printf("\n=== AA C benchmarks (GD on diagonal quadratic) ===\n");
+  printf("optimum is x=0; final_err is ||x|| after `iters` iterations.\n");
+
+  /* -------- Scan: dim --------
+   * cond=1e6 + iters=300 keeps every size in the "still making progress"
+   * regime so the timing comparison reflects productive AA work, not
+   * degenerate post-convergence spinning. */
+  print_header("scan:dim (fixed mem=10, type-II, cond=1e6)");
+  bench_cfg dim_sweep[] = {
+      {"dim=10",      10,    10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
+      {"dim=100",     100,   10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
+      {"dim=1000",    1000,  10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
+      {"dim=5000",    5000,  10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
+      {"dim=20000",   20000, 10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(dim_sweep)/sizeof(*dim_sweep); i++) run_one(dim_sweep[i]);
+
+  /* -------- Scan: mem (set_m is quadratic in mem) -------- */
+  print_header("scan:mem (fixed dim=500, type-II, cond=1e4)");
+  bench_cfg mem_sweep[] = {
+      {"mem=1",       500, 1,   0, 1.0, 1e4, 500, 1e-12, 0.0},
+      {"mem=5",       500, 5,   0, 1.0, 1e4, 500, 1e-12, 0.0},
+      {"mem=10",      500, 10,  0, 1.0, 1e4, 500, 1e-12, 0.0},
+      {"mem=20",      500, 20,  0, 1.0, 1e4, 500, 1e-12, 0.0},
+      {"mem=50",      500, 50,  0, 1.0, 1e4, 500, 1e-12, 0.0},
+      {"mem=100",     500, 100, 0, 1.0, 1e4, 500, 1e-12, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(mem_sweep)/sizeof(*mem_sweep); i++) run_one(mem_sweep[i]);
+
+  /* -------- Scan: type -------- */
+  print_header("scan:type (fixed dim=500, mem=10, cond=1e4)");
+  bench_cfg type_sweep[] = {
+      {"type-I  reg=1e-8",  500, 10, 1, 1.0, 1e4, 1000, 1e-8,  0.0},
+      {"type-I  reg=1e-12", 500, 10, 1, 1.0, 1e4, 1000, 1e-12, 0.0},
+      {"type-II reg=1e-12", 500, 10, 0, 1.0, 1e4, 1000, 1e-12, 0.0},
+      {"type-II reg=0",     500, 10, 0, 1.0, 1e4, 1000, 0.0,   0.0},
+  };
+  for (size_t i = 0; i < sizeof(type_sweep)/sizeof(*type_sweep); i++) run_one(type_sweep[i]);
+
+  /* -------- Scan: cond -------- */
+  print_header("scan:cond (fixed dim=500, mem=10, type-II)");
+  bench_cfg cond_sweep[] = {
+      {"cond=10",    500, 10, 0, 1.0, 10,   500,  1e-12, 0.0},
+      {"cond=100",   500, 10, 0, 1.0, 100,  500,  1e-12, 0.0},
+      {"cond=1e4",   500, 10, 0, 1.0, 1e4,  500,  1e-12, 0.0},
+      {"cond=1e6",   500, 10, 0, 1.0, 1e6,  2000, 1e-12, 0.0},
+      {"cond=1e8",   500, 10, 0, 1.0, 1e8,  2000, 1e-12, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(cond_sweep)/sizeof(*cond_sweep); i++) run_one(cond_sweep[i]);
+
+  /* -------- Relaxation (exercises x_work path) -------- */
+  print_header("relaxation (fixed dim=500, mem=10, cond=1e4)");
+  bench_cfg relax_sweep[] = {
+      {"relax=1.0 (none)",  500, 10, 0, 1.0,  1e4, 1000, 1e-12, 0.0},
+      {"relax=0.95",        500, 10, 0, 0.95, 1e4, 1000, 1e-12, 0.0},
+      {"relax=1.2 (over)",  500, 10, 0, 1.2,  1e4, 1000, 1e-12, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(relax_sweep)/sizeof(*relax_sweep); i++) run_one(relax_sweep[i]);
+
+  /* -------- Near-optimum: machine-precision saturation ------------
+   * Easy well-conditioned problems where AA converges to machine
+   * precision within ~20 iters; the remaining iterations run on
+   * iterates of magnitude O(eps). S, Y columns are denormal noise
+   * and M = Y^T Y has condition number ~ 1/eps^2. This is the
+   * degenerate extreme — gesv starts failing and aa_reset fires.
+   */
+  print_header("near-optimum: long runs past machine-precision convergence");
+  bench_cfg near_opt[] = {
+      {"saturate dim=50",   50,  5,  0, 1.0, 10, 2000, 1e-12, 0.0},
+      {"saturate dim=200",  200, 10, 0, 1.0, 10, 2000, 1e-12, 0.0},
+      {"mem=20 tail",       200, 20, 0, 1.0, 10, 2000, 1e-12, 0.0},
+      {"mem=50 tail",       200, 50, 0, 1.0, 10, 2000, 1e-12, 0.0},
+      {"type-I saturate",   200, 10, 1, 1.0, 10, 2000, 1e-8,  0.0},
+      /* Zero regularization amplifies ill-conditioning — a canary for
+       * the gesv-failure + aa_reset fallback. */
+      {"no-reg saturate",   200, 10, 0, 1.0, 10, 2000, 0.0,   0.0},
+  };
+  for (size_t i = 0; i < sizeof(near_opt)/sizeof(*near_opt); i++) run_one(near_opt[i]);
+
+  /* -------- Near-optimum: the realistic noisy regime ------------
+   * Iterates never reach machine precision — they bounce inside a
+   * ball of radius ~noise_scale. Consecutive iterate differences
+   * are O(noise_scale), not O(eps). This mimics what real solvers
+   * see: stochastic gradients, approximate prox maps, inner solves
+   * with fixed tolerance. The Gram matrix M is ill-conditioned
+   * (signal is O(noise_scale), noise is O(eps·|x|)) but not
+   * denormal — which is actually harder for AA than the degenerate
+   * extreme above, because the regularization has to be tuned for
+   * it but there's no reset-on-failure safety net.
+   */
+  print_header("noisy-floor: realistic near-optimum regime, iter diffs ~ noise_scale");
+  bench_cfg noisy[] = {
+      /* noise_scale = 1e-4: moderate — easy for AA to track. */
+      {"noise=1e-4 type-II", 200, 10, 0, 1.0, 10, 2000, 1e-12, 1e-4},
+      {"noise=1e-4 type-I",  200, 10, 1, 1.0, 10, 2000, 1e-8,  1e-4},
+      /* noise_scale = 1e-6: the regime the user pointed out — iterate
+       * differences of O(1e-6), cancellation in y = g-g_prev is severe
+       * (signal 1e-6, input magnitudes 1e-6, roundoff 1e-22). */
+      {"noise=1e-6 type-II", 200, 10, 0, 1.0, 10, 2000, 1e-12, 1e-6},
+      {"noise=1e-6 type-I",  200, 10, 1, 1.0, 10, 2000, 1e-8,  1e-6},
+      {"noise=1e-6 mem=20",  200, 20, 0, 1.0, 10, 2000, 1e-12, 1e-6},
+      /* noise_scale = 1e-8: tight — iterate differences of O(1e-8)
+       * with double precision gives ~8 digits of signal in the
+       * Gram matrix. Stress test. */
+      {"noise=1e-8 type-II", 200, 10, 0, 1.0, 10, 2000, 1e-12, 1e-8},
+      {"noise=1e-8 type-I",  200, 10, 1, 1.0, 10, 2000, 1e-8,  1e-8},
+      /* Wider problems in the noisy regime: gemv dimension matters. */
+      {"noisy wide dim=2000",2000,10, 0, 1.0, 10, 1000, 1e-12, 1e-6},
+      /* no regularization in the noisy regime — this should be the
+       * most numerically hostile config in the whole bench. Expect
+       * many aa_rej / sg_rej events. */
+      {"noisy no-reg",       200, 10, 0, 1.0, 10, 2000, 0.0,   1e-6},
+  };
+  for (size_t i = 0; i < sizeof(noisy)/sizeof(*noisy); i++) run_one(noisy[i]);
+
+  printf("\n");
+  return 0;
+}

--- a/tests/python/bench.py
+++ b/tests/python/bench.py
@@ -1,0 +1,232 @@
+"""Latency and accuracy benchmarks for the aa Python bindings.
+
+Prints a table of per-configuration numbers; wired into CI after the
+pytest suite so every build leaves a baseline in the logs. Wall times
+on CI runners jitter from run to run — the counters (applies, aa_rej,
+sg_rej) and final_err are the stable regression signals.
+
+Problem: gradient descent on a diagonal convex quadratic
+    (1/2) x^T Q x,  Q = diag(eigs),  eigs uniform in [1/cond, 1],
+    F(x) = x - step * (Qdiag * x),  step = 1 / max(eigs) = 1,
+    optimum at x = 0,  initial x_i = sin((i+1) * 0.1).
+
+The map is intentionally cheap (O(dim)) so AA overhead shows up as a
+meaningful fraction of wall time.
+
+Sweeps:
+    scan:dim        fixed mem, varies dim      (AA scaling in dim)
+    scan:mem        fixed dim, varies mem      (set_m/gemv scaling in mem)
+    scan:type       type-I vs type-II
+    scan:cond       varies conditioning        (convergence pressure)
+    relaxation      exercises x_work path
+    near-optimum    long run past machine-precision convergence — S,Y
+                    columns are denormal noise, M is catastrophically
+                    ill-conditioned. Exercises the aa_reset fallback.
+    noisy-floor     deterministic iter-dependent perturbation in F.
+                    Iterates never converge — they bounce in a ball of
+                    radius ~ noise_scale. This is the realistic
+                    near-optimum regime (stochastic gradients,
+                    approximate prox ops, fixed inner tolerance): the
+                    ~1e-6 iterate-difference world real solvers live in.
+
+Usage:
+    python tests/python/bench.py
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import numpy as np
+
+import aa
+
+
+@dataclass
+class BenchCfg:
+    label: str
+    dim: int
+    mem: int
+    type1: bool
+    relaxation: float
+    cond: float
+    iters: int
+    regularization: float
+    noise_scale: float = 0.0
+
+
+def _run_one(cfg: BenchCfg):
+    n = cfg.dim
+    eig_lo = 1.0 / cfg.cond
+    Qdiag = np.linspace(eig_lo, 1.0, n)
+    x = np.sin(np.arange(1, n + 1) * 0.1)
+    x_prev = x.copy()
+    step = 1.0  # = 1 / max(Qdiag)
+
+    acc = aa.AndersonAccelerator(
+        n, cfg.mem,
+        type1=cfg.type1,
+        regularization=cfg.regularization,
+        relaxation=cfg.relaxation,
+        safeguard_factor=2.0,
+        max_weight_norm=1e10,
+        verbosity=0,
+    )
+
+    aa_s = 0.0
+    applies = aa_rej = sg_rej = 0
+    t_total = time.perf_counter()
+    with np.errstate(over="ignore", invalid="ignore"):
+        for i in range(cfg.iters):
+            if i > 0:
+                t0 = time.perf_counter()
+                w = acc.apply(x, x_prev)
+                aa_s += time.perf_counter() - t0
+                if w > 0:
+                    applies += 1
+                else:
+                    aa_rej += 1
+            x_prev = x.copy()
+            # F(xprev) with optional iter-dependent noise.
+            x -= step * Qdiag * x_prev
+            if cfg.noise_scale > 0:
+                noise = np.sin((i * 131 + np.arange(1, n + 1)) * 0.07)
+                x += cfg.noise_scale * noise
+            t0 = time.perf_counter()
+            sg = acc.safeguard(x, x_prev)
+            aa_s += time.perf_counter() - t0
+            if sg != 0:
+                sg_rej += 1
+    total_s = time.perf_counter() - t_total
+
+    err = float(np.linalg.norm(x))
+    aa_calls = applies + aa_rej
+    us_per_apply = (aa_s * 1e6 / aa_calls) if aa_calls else 0.0
+    aa_frac = (aa_s / total_s) if total_s > 0 else 0.0
+    type_str = "I" if cfg.type1 else "II"
+
+    print(
+        f"{cfg.label:<20s} | {n:6d} {cfg.mem:4d}   {type_str:<2s}  "
+        f"{cfg.relaxation:4.2f} | {cfg.iters:6d} | {err:10.3e} | "
+        f"{applies:6d} {aa_rej:5d} {sg_rej:5d} | {total_s * 1e3:9.2f} | "
+        f"{us_per_apply:9.2f} | {aa_frac * 100:5.1f}%"
+    )
+
+
+def _print_header(section):
+    print(f"\n-- {section} --")
+    print(
+        f"{'label':<20s} | {'dim':>6s} {'mem':>4s} {'type':>4s} {'rlx':>4s} | "
+        f"{'iters':>6s} | {'final_err':>10s} | "
+        f"{'applied':>6s} {'a_rej':>5s} {'s_rej':>5s} | "
+        f"{'total_ms':>9s} | {'us/call':>9s} | {'aa%':>6s}"
+    )
+    print("-" * 136)
+
+
+def _warmup():
+    """Amortize dynamic-linker / kernel-fault costs that would otherwise
+    get charged to the first config."""
+    acc = aa.AndersonAccelerator(50, 5, type1=False, regularization=1e-12)
+    x = np.ones(50)
+    x_prev = x.copy()
+    for i in range(50):
+        if i > 0:
+            acc.apply(x, x_prev)
+        x_prev = x.copy()
+        x *= 0.9
+        acc.safeguard(x, x_prev)
+
+
+def main():
+    print("\n=== AA Python benchmarks (GD on diagonal quadratic) ===")
+    print("optimum is x=0; final_err is ||x|| after `iters` iterations.")
+    _warmup()
+
+    # scan:dim — cond=1e6 + iters=300 keeps every size making progress.
+    _print_header("scan:dim (fixed mem=10, type-II, cond=1e6)")
+    for cfg in [
+        BenchCfg("dim=10",      10,    10, False, 1.0, 1e6, 300, 1e-12),
+        BenchCfg("dim=100",     100,   10, False, 1.0, 1e6, 300, 1e-12),
+        BenchCfg("dim=1000",    1000,  10, False, 1.0, 1e6, 300, 1e-12),
+        BenchCfg("dim=5000",    5000,  10, False, 1.0, 1e6, 300, 1e-12),
+        BenchCfg("dim=20000",   20000, 10, False, 1.0, 1e6, 300, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("scan:mem (fixed dim=500, type-II, cond=1e4)")
+    for cfg in [
+        BenchCfg("mem=1",       500, 1,   False, 1.0, 1e4, 500, 1e-12),
+        BenchCfg("mem=5",       500, 5,   False, 1.0, 1e4, 500, 1e-12),
+        BenchCfg("mem=10",      500, 10,  False, 1.0, 1e4, 500, 1e-12),
+        BenchCfg("mem=20",      500, 20,  False, 1.0, 1e4, 500, 1e-12),
+        BenchCfg("mem=50",      500, 50,  False, 1.0, 1e4, 500, 1e-12),
+        BenchCfg("mem=100",     500, 100, False, 1.0, 1e4, 500, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("scan:type (fixed dim=500, mem=10, cond=1e4)")
+    for cfg in [
+        BenchCfg("type-I  reg=1e-8",  500, 10, True,  1.0, 1e4, 1000, 1e-8),
+        BenchCfg("type-I  reg=1e-12", 500, 10, True,  1.0, 1e4, 1000, 1e-12),
+        BenchCfg("type-II reg=1e-12", 500, 10, False, 1.0, 1e4, 1000, 1e-12),
+        BenchCfg("type-II reg=0",     500, 10, False, 1.0, 1e4, 1000, 0.0),
+    ]:
+        _run_one(cfg)
+
+    _print_header("scan:cond (fixed dim=500, mem=10, type-II)")
+    for cfg in [
+        BenchCfg("cond=10",    500, 10, False, 1.0, 10,    500,  1e-12),
+        BenchCfg("cond=100",   500, 10, False, 1.0, 100,   500,  1e-12),
+        BenchCfg("cond=1e4",   500, 10, False, 1.0, 1e4,   500,  1e-12),
+        BenchCfg("cond=1e6",   500, 10, False, 1.0, 1e6,   2000, 1e-12),
+        BenchCfg("cond=1e8",   500, 10, False, 1.0, 1e8,   2000, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("relaxation (fixed dim=500, mem=10, cond=1e4)")
+    for cfg in [
+        BenchCfg("relax=1.0 (none)",  500, 10, False, 1.0,  1e4, 1000, 1e-12),
+        BenchCfg("relax=0.95",        500, 10, False, 0.95, 1e4, 1000, 1e-12),
+        BenchCfg("relax=1.2 (over)",  500, 10, False, 1.2,  1e4, 1000, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("near-optimum: long runs past machine-precision convergence")
+    for cfg in [
+        BenchCfg("saturate dim=50",   50,  5,  False, 1.0, 10, 2000, 1e-12),
+        BenchCfg("saturate dim=200",  200, 10, False, 1.0, 10, 2000, 1e-12),
+        BenchCfg("mem=20 tail",       200, 20, False, 1.0, 10, 2000, 1e-12),
+        BenchCfg("mem=50 tail",       200, 50, False, 1.0, 10, 2000, 1e-12),
+        BenchCfg("type-I saturate",   200, 10, True,  1.0, 10, 2000, 1e-8),
+        BenchCfg("no-reg saturate",   200, 10, False, 1.0, 10, 2000, 0.0),
+    ]:
+        _run_one(cfg)
+
+    _print_header(
+        "noisy-floor: realistic near-optimum regime, iter diffs ~ noise_scale"
+    )
+    for cfg in [
+        # noise_scale = 1e-4: moderate.
+        BenchCfg("noise=1e-4 type-II", 200, 10, False, 1.0, 10, 2000, 1e-12, 1e-4),
+        BenchCfg("noise=1e-4 type-I",  200, 10, True,  1.0, 10, 2000, 1e-8,  1e-4),
+        # noise_scale = 1e-6: the regime the user pointed out — iterate
+        # differences of O(1e-6) and Gram-matrix signal of the same order.
+        BenchCfg("noise=1e-6 type-II", 200, 10, False, 1.0, 10, 2000, 1e-12, 1e-6),
+        BenchCfg("noise=1e-6 type-I",  200, 10, True,  1.0, 10, 2000, 1e-8,  1e-6),
+        BenchCfg("noise=1e-6 mem=20",  200, 20, False, 1.0, 10, 2000, 1e-12, 1e-6),
+        # noise_scale = 1e-8: tight stress test.
+        BenchCfg("noise=1e-8 type-II", 200, 10, False, 1.0, 10, 2000, 1e-12, 1e-8),
+        BenchCfg("noise=1e-8 type-I",  200, 10, True,  1.0, 10, 2000, 1e-8,  1e-8),
+        # Wider problems in the noisy regime.
+        BenchCfg("noisy wide dim=2000",2000,10, False, 1.0, 10, 1000, 1e-12, 1e-6),
+        # Hostile: no regularization + noise — many rejections expected.
+        BenchCfg("noisy no-reg",       200, 10, False, 1.0, 10, 2000, 0.0,   1e-6),
+    ]:
+        _run_one(cfg)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New C benchmark (`tests/c/bench.c`, wired into `make test` and also exposed as `make bench`)
- New Python benchmark (`tests/python/bench.py`, wired into the CI pytest job)
- Both print per-configuration tables every test run, so CI logs carry a baseline

## What it covers

Sweeps: `dim`, `mem`, type-I vs type-II, conditioning (`cond`), relaxation, plus two near-optimum regimes:

- **machine-precision saturation** — long runs past convergence where S, Y columns are denormal noise and M is catastrophically ill-conditioned. Exercises the `gesv`-failure + `aa_reset` fallback.
- **noisy-floor** — deterministic iter-dependent perturbation injected into F so iterates bounce in a ball of radius ~`noise_scale`. Models realistic solvers (stochastic gradients, approximate prox, fixed inner tolerance) — the *~1e-6 iterate-difference* regime.

Each row reports `final_err`, `applies`, `aa_rej`, `sg_rej`, `total_ms`, `us/apply`, and AA-time fraction. Counters are stable regression signals; wall times will jitter on CI runners (use for order-of-magnitude only).

## Notes

- The `near-optimum` saturation configs currently print `final_err = NaN`. This is a genuine library issue (the `aa_norm >= max_weight_norm` guard doesn't catch NaN because NaN comparisons are false). Being addressed in a separate PR — the benchmark is simply exposing it.
- Python `us/apply` runs 30–50% higher than C at small sizes due to Cython argument-check overhead — expected.

## Test plan
- [x] `make test` on macOS/Accelerate runs the full suite including the bench
- [x] `python tests/python/bench.py` runs standalone
- [ ] CI passes across `build.yml`, `accelerate.yml`, `mkl.yml`, `valgrind.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)