### PR TITLE
aa: reject non-finite AA weights from solve()

### DIFF
--- a/src/aa.c
+++ b/src/aa.c
@@ -22,6 +22,8 @@
  *
  */
 
+#include <math.h>
+
 #include "aa.h"
 #include "aa_blas.h"
 
@@ -291,8 +293,13 @@ static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
            a->type1 ? 1 : 2, (int)a->iter, (int)len, (int)info, aa_norm);
   }
 
-  /* info < 0 input error, input > 0 matrix is singular */
-  if (info != 0 || aa_norm >= a->max_weight_norm) {
+  /* info < 0 input error, info > 0 matrix is singular. gesv can also return
+   * info == 0 with NaN-valued weights when M is numerically rank-deficient
+   * but not LAPACK-singular (happens near the optimum when columns of Y
+   * become denormal); NaN propagates through the gemv below and poisons f.
+   * Guard explicitly with isfinite. Inf is already caught by the weight-norm
+   * check since Inf >= max_weight_norm. */
+  if (info != 0 || !isfinite(aa_norm) || aa_norm >= a->max_weight_norm) {
     if (a->verbosity > 0) {
       printf("Error in AA type %i, iter: %i, len %i, info: %i, aa_norm %.2e\n",
              a->type1 ? 1 : 2, (int)a->iter, (int)len, (int)info, aa_norm);
@@ -301,6 +308,7 @@ static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
     /* reset aa for stability */
     aa_reset(a);
     TIME_TOC
+    if (!isfinite(aa_norm)) aa_norm = -1.0;
     return (aa_norm < 0) ? aa_norm : -aa_norm;
   }
 

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -423,6 +423,51 @@ static const char *test_first_iter_is_noop_on_f(void) {
   return 0;
 }
 
+/* Long GD past machine-precision convergence. Once iterates saturate, Y's
+ * columns are denormal noise and M = Y'Y becomes numerically rank-deficient.
+ * gesv can return info=0 with NaN-valued weights; without an isfinite guard
+ * those NaNs flow through f -= D*work and poison the iterate. Regression
+ * test for that failure mode: after the accelerator has had ample chance
+ * to break down, f must still be finite. */
+static const char *test_post_convergence_stays_finite(void) {
+  const aa_int n = 50;
+  const aa_int mem = 5;
+  const aa_int iters = 2000;
+  aa_float *Qdiag = (aa_float *)malloc(sizeof(aa_float) * n);
+  for (aa_int i = 0; i < n; i++) {
+    /* eigs in [0.1, 1.0] — well-conditioned so GD drives x to 0 fast. */
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / (aa_float)(n - 1);
+  }
+
+  aa_float *x = (aa_float *)malloc(sizeof(aa_float) * n);
+  aa_float *xprev = (aa_float *)malloc(sizeof(aa_float) * n);
+  for (aa_int i = 0; i < n; i++) {
+    x[i] = sin((i + 1) * 0.1); /* deterministic, non-trivial init */
+  }
+
+  AaWork *a = aa_init(n, mem, /*type1=*/0, /*reg=*/1e-12, /*relax=*/1.0,
+                      /*safeguard=*/2.0, /*max_w=*/1e10, /*verbosity=*/0);
+  for (aa_int i = 0; i < iters; i++) {
+    if (i > 0) {
+      aa_apply(x, xprev, a);
+    }
+    memcpy(xprev, x, n * sizeof(aa_float));
+    for (aa_int j = 0; j < n; j++) {
+      x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    }
+    aa_safeguard(x, xprev, a);
+  }
+
+  aa_float err = nrm2_vec(x, n);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  free(Qdiag);
+
+  mu_assert("post-convergence iterate is not finite", isfinite(err));
+  return 0;
+}
+
 /* =============================================================== */
 
 static const char *all_tests(void) {
@@ -459,6 +504,8 @@ static const char *all_tests(void) {
   mu_run_test(test_cyclic_buffer_long_run);
   printf("unit: AA accelerates convergence vs plain GD\n");
   mu_run_test(test_aa_accelerates_convergence);
+  printf("unit: post-convergence iterates stay finite (NaN guard)\n");
+  mu_run_test(test_post_convergence_stays_finite);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

- Near a fixed point, once \`F\` has saturated, columns of \`Y\` become denormal noise and \`M = Y'Y\` (or \`S'Y\`) is numerically rank-deficient but not LAPACK-singular. \`gesv\` returns \`info=0\` with NaN-valued weights.
- The existing guard \`aa_norm >= max_weight_norm\` is unordered for NaN, so the step is accepted and the NaN propagates through \`f -= D * work\`, poisoning the caller's iterate from then on.
- Fix: reject explicitly on \`!isfinite(aa_norm)\` and reset the workspace. Adds \`test_post_convergence_stays_finite\`, a long-run diagonal GD that saturates to machine precision; without the fix, \`||x||\` is NaN.

## Benchmark delta (from the bench suite in #35, \`near-optimum\` section)

All long-run saturate configs go from NaN to clean zero convergence. No change elsewhere — the guard only fires when \`solve\` would have corrupted \`f\`.

**Before (master):**

\`\`\`
saturate dim=50      | final_err=nan
saturate dim=200     | final_err=nan
mem=20 tail          | final_err=nan
mem=50 tail          | final_err=nan
type-I saturate      | final_err=nan
no-reg saturate      | final_err=nan
\`\`\`

**After (this PR):**

\`\`\`
saturate dim=50      | final_err=0.000e+00
saturate dim=200     | final_err=0.000e+00
mem=20 tail          | final_err=0.000e+00
mem=50 tail          | final_err=0.000e+00
type-I saturate      | final_err=0.000e+00
no-reg saturate      | final_err=0.000e+00
\`\`\`

No measurable latency change on the remaining sweeps (\`scan:dim\`, \`scan:mem\`, \`scan:type\`, \`scan:cond\`, \`relaxation\`, \`noisy-floor\`) — the only path modified is the failure branch of \`solve\`.

## Test plan

- [x] New regression test fails on \`master\` (assertion "post-convergence iterate is not finite" fires)
- [x] New regression test passes with the fix
- [x] Full \`make test\` still green
- [x] No behavior change on healthy configs (Gram matrix well-conditioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)