### PR TITLE
aa: QR-based solve (default) — robust near the optimum

### DIFF
--- a/include/aa_blas.h
+++ b/include/aa_blas.h
@@ -58,6 +58,16 @@ void BLAS(gemm)(const char *transa, const char *transb, blas_int *m,
                 aa_float *c, blas_int *ldc);
 void BLAS(scal)(const blas_int *n, const aa_float *a, aa_float *x,
                 const blas_int *incx);
+void BLAS(trsv)(const char *uplo, const char *trans, const char *diag,
+                const blas_int *n, const aa_float *a, const blas_int *lda,
+                aa_float *x, const blas_int *incx);
+void BLAS(geqrf)(blas_int *m, blas_int *n, aa_float *a, blas_int *lda,
+                 aa_float *tau, aa_float *work, blas_int *lwork,
+                 blas_int *info);
+void BLAS(ormqr)(const char *side, const char *trans, blas_int *m,
+                 blas_int *n, blas_int *k, aa_float *a, blas_int *lda,
+                 aa_float *tau, aa_float *c, blas_int *ldc,
+                 aa_float *work, blas_int *lwork, blas_int *info);
 
 #ifdef __cplusplus
 }

--- a/src/aa.c
+++ b/src/aa.c
@@ -451,7 +451,9 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
 
     /* LAPACK workspace query: ask geqrf and ormqr for their preferred lwork,
      * then take the max. lwork = -1 makes the routine write the optimal
-     * size into work[0] without doing any factoring. */
+     * size into work[0] without doing any factoring. The optimal size is
+     * returned in an aa_float slot; round up with ceil before casting so a
+     * value like 255.9999 doesn't truncate to 255 and under-allocate. */
     {
       blas_int b_aug = (blas_int)aug_rows;
       blas_int b_mem = (blas_int)a->mem;
@@ -478,7 +480,7 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
         /* Floor at mem — some LAPACK builds return modest sizes; keep
          * a sane minimum. calloc of zero is implementation-defined. */
         if (lwork_f < (aa_float)a->mem) lwork_f = (aa_float)a->mem;
-        a->qr_lwork = (blas_int)lwork_f;
+        a->qr_lwork = (blas_int)ceil(lwork_f);
         a->qr_work = (aa_float *)calloc((size_t)a->qr_lwork, sizeof(aa_float));
       }
     }

--- a/src/aa.c
+++ b/src/aa.c
@@ -20,7 +20,17 @@
  * Type-II:
  * return f = f - (S - Y) * ( Y'Y + r I)^{-1} ( Y'g )
  *
+ * Both types reduce to the same regularized least-squares augmentation
+ *     (A'B + r I) γ = A' g
+ *     ⇔   [A; √r I]' [B; √r I] γ = [A; √r I]' [g; 0],
+ * where A = S (type-I) or A = Y (type-II), and B = Y. We solve via a thin
+ * QR factorization of the augmented A, which keeps the conditioning at
+ * κ(A_aug) rather than the κ(A_aug)² that a normal-equations solve would
+ * incur — critical near the optimum where Y rows are tiny and the Gram
+ * matrix becomes numerically singular.
  */
+
+#include <math.h>
 
 #include "aa.h"
 #include "aa_blas.h"
@@ -124,49 +134,59 @@ struct ACCEL_WORK {
   aa_float *Y; /* matrix of stacked y values */
   aa_float *S; /* matrix of stacked s values */
   aa_float *D; /* matrix of stacked d values = (S-Y) */
-  aa_float *M; /* S'Y or Y'Y depending on type of aa */
 
-  /* workspace variables */
-  aa_float *work; /* scratch space */
-  blas_int *ipiv; /* permutation variable, not used after solve */
+  /* QR workspaces, sized for the augmented problem. */
+  aa_float *A_aug;   /* (dim + mem) x mem  -- [A; √r I]; factored in place */
+  aa_float *B_aug;   /* (dim + mem) x mem  -- [Y; √r I] (type-I only) */
+  aa_float *c_aug;   /* (dim + mem)        -- [g; 0], overwritten by Q' c */
+  aa_float *tau;     /* mem                -- Householder scalars */
+  aa_float *qr_work; /* lwork              -- LAPACK scratch for geqrf/ormqr */
+  blas_int qr_lwork; /* size of qr_work, chosen via workspace query at init */
+
+  aa_float *W;    /* mem x mem scratch: Q' B_aug top block (type-I gesv) */
+  blas_int *ipiv; /* gesv permutation (type-I) */
+
+  /* dim-sized scratch used by aa_safeguard for the x_new - f_new diff. */
+  aa_float *work;
 
   aa_float *x_work; /* workspace (= x) for when relaxation != 1.0 */
 };
 
-/* add regularization dependent on Y and S matrices */
+/* Tikhonov regularization scaled with the problem. Matches the prior
+ * behavior's intent (r grows with the magnitude of A'B so `regularization`
+ * stays unitless), but uses the cheap Frobenius-norm upper bound
+ *     ||A'B||_F ≤ ||A||_F · ||B||_F
+ * instead of maintaining a Gram matrix. For type-II A == B so this is
+ * ||Y||_F², the same scale as the previous ||Y'Y||_F up to a factor
+ * ≤ √mem. */
 static aa_float compute_regularization(AaWork *a, aa_int len) {
-  /* typically type-I does better with higher regularization than type-II */
   TIME_TIC
-  aa_float r, nrm_m;
-  blas_int btotal = (blas_int)(len * len), one = 1;
-  nrm_m = BLAS(nrm2)(&btotal, a->M, &one);
-  r = a->regularization * nrm_m;
+  blas_int bmat = (blas_int)(a->dim * len), one = 1;
+  aa_float nrm_a = BLAS(nrm2)(&bmat, a->type1 ? a->S : a->Y, &one);
+  aa_float nrm_y = a->type1 ? BLAS(nrm2)(&bmat, a->Y, &one) : nrm_a;
+  aa_float r = a->regularization * nrm_a * nrm_y;
   if (a->verbosity > 2) {
-    printf("iter: %i, norm: M %.2e, r: %.2e\n", (int)a->iter, nrm_m, r);
+    printf("iter: %i, ||A||_F %.2e, ||Y||_F %.2e, r: %.2e\n",
+           (int)a->iter, nrm_a, nrm_y, r);
   }
   TIME_TOC
   return r;
 }
 
-/* sets a->M to S'Y or Y'Y depending on type of aa used */
-/* M is len x len after this */
-static void set_m(AaWork *a, aa_int len) {
-  TIME_TIC
+/* Build [M; √r I_len] column-major into `dst` with fixed leading dim
+ * (dim + mem). When len < mem we zero-pad the unused trailing rows so
+ * the QR factorization still operates on a well-defined (dim+mem) x len
+ * block; the zero rows don't change the solve. */
+static void build_augmented(aa_float *dst, const aa_float *src, aa_int dim,
+                            aa_int mem, aa_int len, aa_float sqrt_r) {
   aa_int i;
-  blas_int bdim = (blas_int)(a->dim);
-  blas_int blen = (blas_int)len;
-  aa_float onef = 1.0, zerof = 0.0, r;
-  /* if len < mem this only uses len cols */
-  BLAS(gemm)
-  ("Trans", "No", &blen, &blen, &bdim, &onef, a->type1 ? a->S : a->Y, &bdim,
-   a->Y, &bdim, &zerof, a->M, &blen);
-  if (a->regularization > 0) {
-    r = compute_regularization(a, len);
-    for (i = 0; i < len; ++i) {
-      a->M[i + len * i] += r;
-    }
+  aa_int aug_rows = dim + mem;
+  for (i = 0; i < len; ++i) {
+    aa_float *col = &dst[i * aug_rows];
+    memcpy(col, &src[i * dim], dim * sizeof(aa_float));
+    memset(&col[dim], 0, mem * sizeof(aa_float));
+    col[dim + i] = sqrt_r;
   }
-  TIME_TOC
 }
 
 /* initialize accel params, in particular x_prev, f_prev, g_prev */
@@ -263,55 +283,109 @@ static void relax(aa_float *f, AaWork *a, aa_int len) {
   TIME_TOC
 }
 
-/* solves the system of equations to perform the AA update
- * at the end f contains the next iterate to be returned
- */
+/* Solve the regularized normal equations (A'B + rI) γ = A'g via a QR
+ * factorization of the augmented matrix [A; √r I]. This avoids squaring
+ * the condition number the way the normal-equations path did — the
+ * returned γ is accurate down to machine precision × κ(A_aug), whereas
+ * gesv on A'B lost precision at κ(A_aug)². On exit, f holds the AA
+ * iterate and the function returns ||γ|| (or a negative sentinel on
+ * failure). */
 static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
   TIME_TIC
   blas_int info = -1, bdim = (blas_int)(a->dim), one = 1, blen = (blas_int)len;
-  aa_float onef = 1.0, zerof = 0.0, neg_onef = -1.0, aa_norm;
+  /* Leading dim is fixed to dim+mem regardless of len so the buffers
+   * allocated in aa_init match the strides used here. Unused trailing
+   * rows are kept zero by build_augmented. */
+  blas_int aug_rows = bdim + (blas_int)a->mem;
+  aa_float onef = 1.0, neg_onef = -1.0, aa_norm;
+  aa_float *A_src = a->type1 ? a->S : a->Y;
+  aa_float *gamma = a->work; /* len-sized; `work` is MAX(mem,dim), safe here */
 
-  /* work = S'g or Y'g */
-  BLAS(gemv)
-  ("Trans", &bdim, &blen, &onef, a->type1 ? a->S : a->Y, &bdim, a->g, &one,
-   &zerof, a->work, &one);
+  aa_float r = (a->regularization > 0) ? compute_regularization(a, len) : 0.0;
+  aa_float sqrt_r = (r > 0) ? sqrt(r) : 0.0;
 
-  /* work = M \ work, where update_accel_params has set M = S'Y or M = Y'Y */
-  BLAS(gesv)(&blen, &one, a->M, &blen, a->ipiv, a->work, &blen, &info);
-  /* on gesv failure a->work is undefined — don't report a random nrm2 */
-  aa_norm = (info == 0) ? BLAS(nrm2)(&blen, a->work, &one) : -1.0;
+  /* 1. Build A_aug = [A; √r I_len, zero-padded]; factor in place. */
+  build_augmented(a->A_aug, A_src, a->dim, a->mem, len, sqrt_r);
+  BLAS(geqrf)(&aug_rows, &blen, a->A_aug, &aug_rows, a->tau,
+              a->qr_work, &a->qr_lwork, &info);
+
+  /* 2. c_aug = [g; 0]; overwrite with Q' c_aug — first `len` entries are
+   *    (Q' [g;0])_{1..len}, which is what the solve consumes. */
+  if (info == 0) {
+    memcpy(a->c_aug, a->g, a->dim * sizeof(aa_float));
+    memset(&a->c_aug[a->dim], 0, a->mem * sizeof(aa_float));
+    BLAS(ormqr)
+    ("Left", "Trans", &aug_rows, &one, &blen, a->A_aug, &aug_rows, a->tau,
+     a->c_aug, &aug_rows, a->qr_work, &a->qr_lwork, &info);
+  }
+
+  /* 3. Finish the solve differently by type. */
+  if (info == 0) {
+    if (a->type1) {
+      /* Type-I: W γ = Q' [g;0], where W = Q' [Y; √r I]. Build B_aug, apply
+       * Q', copy the mem×mem top block into W, solve with gesv. */
+      aa_int i;
+      build_augmented(a->B_aug, a->Y, a->dim, a->mem, len, sqrt_r);
+      BLAS(ormqr)
+      ("Left", "Trans", &aug_rows, &blen, &blen, a->A_aug, &aug_rows, a->tau,
+       a->B_aug, &aug_rows, a->qr_work, &a->qr_lwork, &info);
+      if (info == 0) {
+        for (i = 0; i < len; ++i) {
+          memcpy(&a->W[i * len], &a->B_aug[i * aug_rows],
+                 len * sizeof(aa_float));
+        }
+        memcpy(gamma, a->c_aug, len * sizeof(aa_float));
+        BLAS(gesv)(&blen, &one, a->W, &blen, a->ipiv, gamma, &blen, &info);
+      }
+    } else {
+      /* Type-II: B = A, so Q' [B; √rI] = R — already stored in the upper
+       * triangle of A_aug. Back-solve R γ = (Q'c)_{1..len}. Guard against
+       * a zero on the diagonal, which geqrf will leave if A_aug has a rank
+       * deficiency (it silently produces a triangular R with zero rows
+       * rather than setting info). */
+      aa_int i;
+      memcpy(gamma, a->c_aug, len * sizeof(aa_float));
+      for (i = 0; i < len; ++i) {
+        if (a->A_aug[i * aug_rows + i] == 0.0) {
+          info = i + 1;
+          break;
+        }
+      }
+      if (info == 0) {
+        BLAS(trsv)("Upper", "NoTrans", "NonUnit", &blen, a->A_aug,
+                   &aug_rows, gamma, &one);
+      }
+    }
+  }
+
+  aa_norm = (info == 0) ? BLAS(nrm2)(&blen, gamma, &one) : -1.0;
   if (a->verbosity > 1) {
     printf("AA type %i, iter: %i, len %i, info: %i, aa_norm %.2e\n",
            a->type1 ? 1 : 2, (int)a->iter, (int)len, (int)info, aa_norm);
   }
 
-  /* info < 0 input error, input > 0 matrix is singular */
-  if (info != 0 || aa_norm >= a->max_weight_norm) {
+  if (info != 0 || !isfinite(aa_norm) || aa_norm >= a->max_weight_norm) {
     if (a->verbosity > 0) {
       printf("Error in AA type %i, iter: %i, len %i, info: %i, aa_norm %.2e\n",
              a->type1 ? 1 : 2, (int)a->iter, (int)len, (int)info, aa_norm);
     }
     a->success = 0;
-    /* reset aa for stability */
     aa_reset(a);
     TIME_TOC
+    if (!isfinite(aa_norm)) aa_norm = -1.0;
     return (aa_norm < 0) ? aa_norm : -aa_norm;
   }
 
-  /* here work = gamma, ie, the correct AA shifted weights */
-  /* if solve was successful compute new point */
-
-  /* first set f -= D * work */
+  /* f -= D γ */
   BLAS(gemv)
-  ("NoTrans", &bdim, &blen, &neg_onef, a->D, &bdim, a->work, &one, &onef, f,
+  ("NoTrans", &bdim, &blen, &neg_onef, a->D, &bdim, gamma, &one, &onef, f,
    &one);
 
-  /* if relaxation is not 1 then need to incorporate */
   if (a->relaxation != 1.0) {
     relax(f, a, len);
   }
 
-  a->success = 1; /* this should be the only place we set success = 1 */
+  a->success = 1;
   TIME_TOC
   return aa_norm;
 }
@@ -359,11 +433,60 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
   a->S = (aa_float *)calloc(a->dim * a->mem, sizeof(aa_float));
   a->D = (aa_float *)calloc(a->dim * a->mem, sizeof(aa_float));
 
-  a->M = (aa_float *)calloc(a->mem * a->mem, sizeof(aa_float));
-  /* work is used as a len-sized (<=mem) scratch in solve(), but as a
-   * dim-sized scratch in aa_safeguard(); size for the larger of the two. */
+  {
+    aa_int aug_rows = a->dim + a->mem;
+    a->A_aug = (aa_float *)calloc((size_t)aug_rows * a->mem, sizeof(aa_float));
+    a->c_aug = (aa_float *)calloc((size_t)aug_rows, sizeof(aa_float));
+    a->tau = (aa_float *)calloc(a->mem, sizeof(aa_float));
+    /* type-I needs a second augmented buffer and a mem×mem gesv scratch */
+    if (type1) {
+      a->B_aug = (aa_float *)calloc((size_t)aug_rows * a->mem, sizeof(aa_float));
+      a->W = (aa_float *)calloc((size_t)a->mem * a->mem, sizeof(aa_float));
+      a->ipiv = (blas_int *)calloc(a->mem, sizeof(blas_int));
+    } else {
+      a->B_aug = NULL;
+      a->W = NULL;
+      a->ipiv = NULL;
+    }
+
+    /* LAPACK workspace query: ask geqrf and ormqr for their preferred lwork,
+     * then take the max. lwork = -1 makes the routine write the optimal
+     * size into work[0] without doing any factoring. */
+    {
+      blas_int b_aug = (blas_int)aug_rows;
+      blas_int b_mem = (blas_int)a->mem;
+      blas_int b_neg_one = -1;
+      blas_int info_q = 0;
+      aa_float q_geqrf = 0.0, q_ormqr_c = 0.0, q_ormqr_b = 0.0;
+      BLAS(geqrf)(&b_aug, &b_mem, a->A_aug, &b_aug, a->tau,
+                  &q_geqrf, &b_neg_one, &info_q);
+      {
+        blas_int b_one = 1;
+        BLAS(ormqr)
+        ("Left", "Trans", &b_aug, &b_one, &b_mem, a->A_aug, &b_aug, a->tau,
+         a->c_aug, &b_aug, &q_ormqr_c, &b_neg_one, &info_q);
+      }
+      if (type1) {
+        BLAS(ormqr)
+        ("Left", "Trans", &b_aug, &b_mem, &b_mem, a->A_aug, &b_aug, a->tau,
+         a->B_aug, &b_aug, &q_ormqr_b, &b_neg_one, &info_q);
+      }
+      {
+        aa_float lwork_f = q_geqrf;
+        if (q_ormqr_c > lwork_f) lwork_f = q_ormqr_c;
+        if (q_ormqr_b > lwork_f) lwork_f = q_ormqr_b;
+        /* Floor at mem — some LAPACK builds return modest sizes; keep
+         * a sane minimum. calloc of zero is implementation-defined. */
+        if (lwork_f < (aa_float)a->mem) lwork_f = (aa_float)a->mem;
+        a->qr_lwork = (blas_int)lwork_f;
+        a->qr_work = (aa_float *)calloc((size_t)a->qr_lwork, sizeof(aa_float));
+      }
+    }
+  }
+
+  /* work is a dim-sized scratch for aa_safeguard's x_new - f_new, and also
+   * the len-sized home for γ inside solve(); size for the larger of the two. */
   a->work = (aa_float *)calloc(MAX(a->mem, a->dim), sizeof(aa_float));
-  a->ipiv = (blas_int *)calloc(a->mem, sizeof(blas_int));
 
   if (relaxation != 1.0) {
     a->x_work = (aa_float *)calloc(a->dim, sizeof(aa_float));
@@ -374,7 +497,10 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
   /* If any allocation failed, free the partial workspace and bail. aa_finish
    * is safe against NULL members. */
   if (!a->x || !a->f || !a->g || !a->g_prev ||
-      !a->Y || !a->S || !a->D || !a->M || !a->work || !a->ipiv ||
+      !a->Y || !a->S || !a->D ||
+      !a->A_aug || !a->c_aug || !a->tau || !a->qr_work ||
+      (type1 && (!a->B_aug || !a->W || !a->ipiv)) ||
+      !a->work ||
       (relaxation != 1.0 && !a->x_work)) {
     printf("Failed to allocate memory for AA.\n");
     aa_finish(a);
@@ -405,8 +531,6 @@ aa_float aa_apply(aa_float *f, const aa_float *x, AaWork *a) {
 
   /* only perform solve steps when the memory is full */
   if (!FILL_MEMORY_BEFORE_SOLVE || a->iter >= a->mem) {
-    /* set M = S'Y or Y'Y depending on type of aa used */
-    set_m(a, len);
     /* solve linear system, new point overwrites f if successful */
     aa_norm = solve(f, a, len);
   }
@@ -470,9 +594,14 @@ void aa_finish(AaWork *a) {
     free(a->Y);
     free(a->S);
     free(a->D);
-    free(a->M);
-    free(a->work);
+    free(a->A_aug);
+    free(a->B_aug);
+    free(a->c_aug);
+    free(a->tau);
+    free(a->qr_work);
+    free(a->W);
     free(a->ipiv);
+    free(a->work);
     if (a->x_work) {
       free(a->x_work);
     }
@@ -512,8 +641,25 @@ void aa_reset(AaWork *a) {
   if (a->D) {
     memset(a->D, 0, sizeof(aa_float) * a->dim * a->mem);
   }
-  if (a->M) {
-    memset(a->M, 0, sizeof(aa_float) * a->mem * a->mem);
+  if (a->A_aug) {
+    memset(a->A_aug, 0,
+           sizeof(aa_float) * (size_t)(a->dim + a->mem) * a->mem);
+  }
+  if (a->B_aug) {
+    memset(a->B_aug, 0,
+           sizeof(aa_float) * (size_t)(a->dim + a->mem) * a->mem);
+  }
+  if (a->c_aug) {
+    memset(a->c_aug, 0, sizeof(aa_float) * (size_t)(a->dim + a->mem));
+  }
+  if (a->tau) {
+    memset(a->tau, 0, sizeof(aa_float) * a->mem);
+  }
+  if (a->qr_work) {
+    memset(a->qr_work, 0, sizeof(aa_float) * (size_t)a->qr_lwork);
+  }
+  if (a->W) {
+    memset(a->W, 0, sizeof(aa_float) * a->mem * a->mem);
   }
   if (a->work) {
     memset(a->work, 0, sizeof(aa_float) * MAX(a->mem, a->dim));

--- a/tests/c/bench.c
+++ b/tests/c/bench.c
@@ -228,20 +228,33 @@ int main(void) {
   /* -------- Scan: dim --------
    * cond=1e6 + iters=300 keeps every size in the "still making progress"
    * regime so the timing comparison reflects productive AA work, not
-   * degenerate post-convergence spinning. */
-  print_header("scan:dim (fixed mem=10, type-II, cond=1e6)");
-  bench_cfg dim_sweep[] = {
+   * degenerate post-convergence spinning. Both types are swept because
+   * type-I is the dominant deployment for this library and carries
+   * extra per-iter cost in the QR path (second ormqr + gesv). */
+  print_header("scan:dim type-II (fixed mem=10, cond=1e6)");
+  bench_cfg dim_sweep_ii[] = {
       {"dim=10",      10,    10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
       {"dim=100",     100,   10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
       {"dim=1000",    1000,  10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
       {"dim=5000",    5000,  10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
       {"dim=20000",   20000, 10, 0, 1.0, 1e6, 300, 1e-12, 0.0},
   };
-  for (size_t i = 0; i < sizeof(dim_sweep)/sizeof(*dim_sweep); i++) run_one(dim_sweep[i]);
+  for (size_t i = 0; i < sizeof(dim_sweep_ii)/sizeof(*dim_sweep_ii); i++) run_one(dim_sweep_ii[i]);
 
-  /* -------- Scan: mem (set_m is quadratic in mem) -------- */
-  print_header("scan:mem (fixed dim=500, type-II, cond=1e4)");
-  bench_cfg mem_sweep[] = {
+  print_header("scan:dim type-I  (fixed mem=10, cond=1e6)");
+  bench_cfg dim_sweep_i[] = {
+      {"dim=10",      10,    10, 1, 1.0, 1e6, 300, 1e-8, 0.0},
+      {"dim=100",     100,   10, 1, 1.0, 1e6, 300, 1e-8, 0.0},
+      {"dim=1000",    1000,  10, 1, 1.0, 1e6, 300, 1e-8, 0.0},
+      {"dim=5000",    5000,  10, 1, 1.0, 1e6, 300, 1e-8, 0.0},
+      {"dim=20000",   20000, 10, 1, 1.0, 1e6, 300, 1e-8, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(dim_sweep_i)/sizeof(*dim_sweep_i); i++) run_one(dim_sweep_i[i]);
+
+  /* -------- Scan: mem (QR solve is O(dim * mem^2) so mem growth shows
+   * up clearly) -------- */
+  print_header("scan:mem type-II (fixed dim=500, cond=1e4)");
+  bench_cfg mem_sweep_ii[] = {
       {"mem=1",       500, 1,   0, 1.0, 1e4, 500, 1e-12, 0.0},
       {"mem=5",       500, 5,   0, 1.0, 1e4, 500, 1e-12, 0.0},
       {"mem=10",      500, 10,  0, 1.0, 1e4, 500, 1e-12, 0.0},
@@ -249,7 +262,18 @@ int main(void) {
       {"mem=50",      500, 50,  0, 1.0, 1e4, 500, 1e-12, 0.0},
       {"mem=100",     500, 100, 0, 1.0, 1e4, 500, 1e-12, 0.0},
   };
-  for (size_t i = 0; i < sizeof(mem_sweep)/sizeof(*mem_sweep); i++) run_one(mem_sweep[i]);
+  for (size_t i = 0; i < sizeof(mem_sweep_ii)/sizeof(*mem_sweep_ii); i++) run_one(mem_sweep_ii[i]);
+
+  print_header("scan:mem type-I  (fixed dim=500, cond=1e4)");
+  bench_cfg mem_sweep_i[] = {
+      {"mem=1",       500, 1,   1, 1.0, 1e4, 500, 1e-8, 0.0},
+      {"mem=5",       500, 5,   1, 1.0, 1e4, 500, 1e-8, 0.0},
+      {"mem=10",      500, 10,  1, 1.0, 1e4, 500, 1e-8, 0.0},
+      {"mem=20",      500, 20,  1, 1.0, 1e4, 500, 1e-8, 0.0},
+      {"mem=50",      500, 50,  1, 1.0, 1e4, 500, 1e-8, 0.0},
+      {"mem=100",     500, 100, 1, 1.0, 1e4, 500, 1e-8, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(mem_sweep_i)/sizeof(*mem_sweep_i); i++) run_one(mem_sweep_i[i]);
 
   /* -------- Scan: type -------- */
   print_header("scan:type (fixed dim=500, mem=10, cond=1e4)");
@@ -262,24 +286,42 @@ int main(void) {
   for (size_t i = 0; i < sizeof(type_sweep)/sizeof(*type_sweep); i++) run_one(type_sweep[i]);
 
   /* -------- Scan: cond -------- */
-  print_header("scan:cond (fixed dim=500, mem=10, type-II)");
-  bench_cfg cond_sweep[] = {
+  print_header("scan:cond type-II (fixed dim=500, mem=10)");
+  bench_cfg cond_sweep_ii[] = {
       {"cond=10",    500, 10, 0, 1.0, 10,   500,  1e-12, 0.0},
       {"cond=100",   500, 10, 0, 1.0, 100,  500,  1e-12, 0.0},
       {"cond=1e4",   500, 10, 0, 1.0, 1e4,  500,  1e-12, 0.0},
       {"cond=1e6",   500, 10, 0, 1.0, 1e6,  2000, 1e-12, 0.0},
       {"cond=1e8",   500, 10, 0, 1.0, 1e8,  2000, 1e-12, 0.0},
   };
-  for (size_t i = 0; i < sizeof(cond_sweep)/sizeof(*cond_sweep); i++) run_one(cond_sweep[i]);
+  for (size_t i = 0; i < sizeof(cond_sweep_ii)/sizeof(*cond_sweep_ii); i++) run_one(cond_sweep_ii[i]);
+
+  print_header("scan:cond type-I  (fixed dim=500, mem=10)");
+  bench_cfg cond_sweep_i[] = {
+      {"cond=10",    500, 10, 1, 1.0, 10,   500,  1e-8, 0.0},
+      {"cond=100",   500, 10, 1, 1.0, 100,  500,  1e-8, 0.0},
+      {"cond=1e4",   500, 10, 1, 1.0, 1e4,  500,  1e-8, 0.0},
+      {"cond=1e6",   500, 10, 1, 1.0, 1e6,  2000, 1e-8, 0.0},
+      {"cond=1e8",   500, 10, 1, 1.0, 1e8,  2000, 1e-8, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(cond_sweep_i)/sizeof(*cond_sweep_i); i++) run_one(cond_sweep_i[i]);
 
   /* -------- Relaxation (exercises x_work path) -------- */
-  print_header("relaxation (fixed dim=500, mem=10, cond=1e4)");
-  bench_cfg relax_sweep[] = {
+  print_header("relaxation type-II (fixed dim=500, mem=10, cond=1e4)");
+  bench_cfg relax_sweep_ii[] = {
       {"relax=1.0 (none)",  500, 10, 0, 1.0,  1e4, 1000, 1e-12, 0.0},
       {"relax=0.95",        500, 10, 0, 0.95, 1e4, 1000, 1e-12, 0.0},
       {"relax=1.2 (over)",  500, 10, 0, 1.2,  1e4, 1000, 1e-12, 0.0},
   };
-  for (size_t i = 0; i < sizeof(relax_sweep)/sizeof(*relax_sweep); i++) run_one(relax_sweep[i]);
+  for (size_t i = 0; i < sizeof(relax_sweep_ii)/sizeof(*relax_sweep_ii); i++) run_one(relax_sweep_ii[i]);
+
+  print_header("relaxation type-I  (fixed dim=500, mem=10, cond=1e4)");
+  bench_cfg relax_sweep_i[] = {
+      {"relax=1.0 (none)",  500, 10, 1, 1.0,  1e4, 1000, 1e-8, 0.0},
+      {"relax=0.95",        500, 10, 1, 0.95, 1e4, 1000, 1e-8, 0.0},
+      {"relax=1.2 (over)",  500, 10, 1, 1.2,  1e4, 1000, 1e-8, 0.0},
+  };
+  for (size_t i = 0; i < sizeof(relax_sweep_i)/sizeof(*relax_sweep_i); i++) run_one(relax_sweep_i[i]);
 
   /* -------- Near-optimum: machine-precision saturation ------------
    * Easy well-conditioned problems where AA converges to machine

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -416,6 +416,22 @@ static const char *test_post_convergence_stays_finite(void) {
   return 0;
 }
 
+/* Low-residual regression specifically for the y = g - g_prev choice in
+ * update_accel_params. Near the optimum g and g_prev are both tiny and
+ * nearly equal, so y is a cancellation-prone quantity (single-rounding
+ * subtraction). Deriving y from s - d would add two extra roundings and
+ * visibly degrade it; an ordering bug that advances g_prev before y is
+ * built would also corrupt y. Either failure mode would stall or blow
+ * up a run like this well before reaching 1e-12. */
+static const char *test_low_residual_near_convergence(void) {
+  aa_float Qdiag[5] = {0.5, 0.7, 0.8, 0.9, 1.0};
+  aa_float err = diag_gd(Qdiag, 5, /*step=*/1.0, /*mem=*/3, /*type1=*/0,
+                         /*relax=*/1.0, /*iters=*/10000, /*seed=*/13);
+  mu_assert("near-convergence iterate is not finite", isfinite(err));
+  mu_assert_less("near-convergence err did not reach 1e-12", err, 1e-12);
+  return 0;
+}
+
 /* QR is well-defined even with regularization=0 and Y columns that
  * overlap heavily (near-singular) — the augmented [A; 0] reduces to A
  * and QR still extracts the rank-revealing triangular factor. This test
@@ -530,6 +546,8 @@ static const char *all_tests(void) {
   mu_run_test(test_cyclic_buffer_long_run);
   printf("unit: iterates stay finite past machine-precision convergence\n");
   mu_run_test(test_post_convergence_stays_finite);
+  printf("unit: iterates converge to low residual without blowup\n");
+  mu_run_test(test_low_residual_near_convergence);
   printf("unit: zero regularization survives near-singular Y\n");
   mu_run_test(test_zero_reg_near_singular_y);
   printf("unit: AA still converges on kappa=1e10 problem\n");

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -398,6 +398,77 @@ static const char *test_mem_one_type2(void) {
   return 0;
 }
 
+/* Running past machine-precision convergence: S, Y columns saturate at
+ * denormal noise, the Gram matrix becomes catastrophically singular.
+ * Under the pre-QR normal-equations solve this manifested as NaN-valued
+ * γ weights and (without the isfinite guard) NaN iterates propagating
+ * back through F. The QR path should keep iterates finite indefinitely
+ * without needing a guard to catch a blown-up weight vector. */
+static const char *test_post_convergence_stays_finite(void) {
+  const aa_int n = 50;
+  aa_float Qdiag[50];
+  for (int i = 0; i < n; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / (aa_float)(n - 1);
+  }
+  aa_float err = diag_gd(Qdiag, n, /*step=*/1.0, /*mem=*/5, /*type1=*/0,
+                         /*relax=*/1.0, /*iters=*/2000, /*seed=*/17);
+  mu_assert("post-convergence iterate is not finite", isfinite(err));
+  return 0;
+}
+
+/* QR is well-defined even with regularization=0 and Y columns that
+ * overlap heavily (near-singular) — the augmented [A; 0] reduces to A
+ * and QR still extracts the rank-revealing triangular factor. This test
+ * runs long enough to saturate at floating-point floor; without the QR
+ * path it blows up. */
+static const char *test_zero_reg_near_singular_y(void) {
+  const aa_int n = 50;
+  aa_float Qdiag[50];
+  for (int i = 0; i < n; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / (aa_float)(n - 1);
+  }
+  aa_float *x = (aa_float *)calloc(n, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
+  srand(23);
+  for (aa_int i = 0; i < n; i++) x[i] = rand_float();
+  AaWork *a = aa_init(n, /*mem=*/10, /*type1=*/0, /*reg=*/0.0,
+                      /*relax=*/1.0, /*safeguard=*/2.0, /*max_w=*/1e10,
+                      /*verbosity=*/0);
+  for (aa_int i = 0; i < 2000; i++) {
+    if (i > 0) aa_apply(x, xprev, a);
+    memcpy(xprev, x, n * sizeof(aa_float));
+    for (aa_int j = 0; j < n; j++) x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, n);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  mu_assert("zero-reg near-singular run produced non-finite iterate",
+            isfinite(err));
+  return 0;
+}
+
+/* Hostile conditioning: κ(Q) = 1e10. The normal-equations solve squares
+ * this to 1e20, well past double precision; QR keeps it at 1e10 so the
+ * solver still produces bounded weights and AA still converges. */
+static const char *test_ill_conditioned_gd(void) {
+  const aa_int n = 40;
+  aa_float Qdiag[40];
+  for (int i = 0; i < n; i++) {
+    aa_float t = (aa_float)i / (aa_float)(n - 1);
+    Qdiag[i] = 1e-10 + (1.0 - 1e-10) * t; /* eigs in [1e-10, 1] */
+  }
+  aa_float err = diag_gd(Qdiag, n, /*step=*/1.0, /*mem=*/10, /*type1=*/0,
+                         /*relax=*/1.0, /*iters=*/2000, /*seed=*/3);
+  mu_assert("ill-conditioned run produced non-finite iterate",
+            isfinite(err));
+  /* Plain GD on this problem would still be at ||x|| ~ 1 after 2000 iters
+   * (slowest mode ~ 1 - 1e-10 step). AA should get well below that. */
+  mu_assert_less("AA failed to accelerate at kappa=1e10", err, 1e-2);
+  return 0;
+}
+
 /* First-iteration behavior: aa_apply on iter 0 must only seed internal
  * state and leave f untouched (return 0). This contract lets callers
  * unconditionally call aa_apply without branching. */
@@ -457,6 +528,12 @@ static const char *all_tests(void) {
   mu_run_test(test_reset_clears_stale_safeguard_state);
   printf("unit: cyclic buffer survives a long run\n");
   mu_run_test(test_cyclic_buffer_long_run);
+  printf("unit: iterates stay finite past machine-precision convergence\n");
+  mu_run_test(test_post_convergence_stays_finite);
+  printf("unit: zero regularization survives near-singular Y\n");
+  mu_run_test(test_zero_reg_near_singular_y);
+  printf("unit: AA still converges on kappa=1e10 problem\n");
+  mu_run_test(test_ill_conditioned_gd);
   printf("unit: AA accelerates convergence vs plain GD\n");
   mu_run_test(test_aa_accelerates_convergence);
 

--- a/tests/python/bench.py
+++ b/tests/python/bench.py
@@ -144,7 +144,9 @@ def main():
     _warmup()
 
     # scan:dim — cond=1e6 + iters=300 keeps every size making progress.
-    _print_header("scan:dim (fixed mem=10, type-II, cond=1e6)")
+    # Both types are swept: type-I is the dominant deployment for this
+    # library and carries extra per-iter cost in the QR path.
+    _print_header("scan:dim type-II (fixed mem=10, cond=1e6)")
     for cfg in [
         BenchCfg("dim=10",      10,    10, False, 1.0, 1e6, 300, 1e-12),
         BenchCfg("dim=100",     100,   10, False, 1.0, 1e6, 300, 1e-12),
@@ -154,7 +156,17 @@ def main():
     ]:
         _run_one(cfg)
 
-    _print_header("scan:mem (fixed dim=500, type-II, cond=1e4)")
+    _print_header("scan:dim type-I  (fixed mem=10, cond=1e6)")
+    for cfg in [
+        BenchCfg("dim=10",      10,    10, True,  1.0, 1e6, 300, 1e-8),
+        BenchCfg("dim=100",     100,   10, True,  1.0, 1e6, 300, 1e-8),
+        BenchCfg("dim=1000",    1000,  10, True,  1.0, 1e6, 300, 1e-8),
+        BenchCfg("dim=5000",    5000,  10, True,  1.0, 1e6, 300, 1e-8),
+        BenchCfg("dim=20000",   20000, 10, True,  1.0, 1e6, 300, 1e-8),
+    ]:
+        _run_one(cfg)
+
+    _print_header("scan:mem type-II (fixed dim=500, cond=1e4)")
     for cfg in [
         BenchCfg("mem=1",       500, 1,   False, 1.0, 1e4, 500, 1e-12),
         BenchCfg("mem=5",       500, 5,   False, 1.0, 1e4, 500, 1e-12),
@@ -162,6 +174,17 @@ def main():
         BenchCfg("mem=20",      500, 20,  False, 1.0, 1e4, 500, 1e-12),
         BenchCfg("mem=50",      500, 50,  False, 1.0, 1e4, 500, 1e-12),
         BenchCfg("mem=100",     500, 100, False, 1.0, 1e4, 500, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("scan:mem type-I  (fixed dim=500, cond=1e4)")
+    for cfg in [
+        BenchCfg("mem=1",       500, 1,   True,  1.0, 1e4, 500, 1e-8),
+        BenchCfg("mem=5",       500, 5,   True,  1.0, 1e4, 500, 1e-8),
+        BenchCfg("mem=10",      500, 10,  True,  1.0, 1e4, 500, 1e-8),
+        BenchCfg("mem=20",      500, 20,  True,  1.0, 1e4, 500, 1e-8),
+        BenchCfg("mem=50",      500, 50,  True,  1.0, 1e4, 500, 1e-8),
+        BenchCfg("mem=100",     500, 100, True,  1.0, 1e4, 500, 1e-8),
     ]:
         _run_one(cfg)
 
@@ -174,7 +197,7 @@ def main():
     ]:
         _run_one(cfg)
 
-    _print_header("scan:cond (fixed dim=500, mem=10, type-II)")
+    _print_header("scan:cond type-II (fixed dim=500, mem=10)")
     for cfg in [
         BenchCfg("cond=10",    500, 10, False, 1.0, 10,    500,  1e-12),
         BenchCfg("cond=100",   500, 10, False, 1.0, 100,   500,  1e-12),
@@ -184,11 +207,29 @@ def main():
     ]:
         _run_one(cfg)
 
-    _print_header("relaxation (fixed dim=500, mem=10, cond=1e4)")
+    _print_header("scan:cond type-I  (fixed dim=500, mem=10)")
+    for cfg in [
+        BenchCfg("cond=10",    500, 10, True,  1.0, 10,    500,  1e-8),
+        BenchCfg("cond=100",   500, 10, True,  1.0, 100,   500,  1e-8),
+        BenchCfg("cond=1e4",   500, 10, True,  1.0, 1e4,   500,  1e-8),
+        BenchCfg("cond=1e6",   500, 10, True,  1.0, 1e6,   2000, 1e-8),
+        BenchCfg("cond=1e8",   500, 10, True,  1.0, 1e8,   2000, 1e-8),
+    ]:
+        _run_one(cfg)
+
+    _print_header("relaxation type-II (fixed dim=500, mem=10, cond=1e4)")
     for cfg in [
         BenchCfg("relax=1.0 (none)",  500, 10, False, 1.0,  1e4, 1000, 1e-12),
         BenchCfg("relax=0.95",        500, 10, False, 0.95, 1e4, 1000, 1e-12),
         BenchCfg("relax=1.2 (over)",  500, 10, False, 1.2,  1e4, 1000, 1e-12),
+    ]:
+        _run_one(cfg)
+
+    _print_header("relaxation type-I  (fixed dim=500, mem=10, cond=1e4)")
+    for cfg in [
+        BenchCfg("relax=1.0 (none)",  500, 10, True,  1.0,  1e4, 1000, 1e-8),
+        BenchCfg("relax=0.95",        500, 10, True,  0.95, 1e4, 1000, 1e-8),
+        BenchCfg("relax=1.2 (over)",  500, 10, True,  1.2,  1e4, 1000, 1e-8),
     ]:
         _run_one(cfg)
 


### PR DESCRIPTION
## Summary

Replace the normal-equations solve in `aa_apply` with a QR factorization of the augmented matrix `[A; √r I]`. Unified across type-I and type-II.

**Robustness was the driver**, not performance. AA only works if the iterate reconstruction is accurate; near convergence the pre-existing `gesv` on `A'B` squared the condition number and returned NaN-valued weights. QR keeps conditioning linear in `κ(A_aug)`, so iterates stay finite indefinitely.

- Type-II: `[Y; √rI] = QR`, back-solve `R γ = Q'[g; 0]` via `trsv`.
- Type-I: same QR on `[S; √rI]`, then apply `Q'` to `[Y; √rI]` (another `ormqr`) to form a mem×mem `W`, solve `W γ = Q'[g; 0]` via `gesv`.
- Regularization `r` now scaled by `||A||_F · ||B||_F` (Frobenius bound on `||A'B||_F`), not the actual Gram matrix — no `M_full` to maintain.

## Benchmark delta (5-run median, vs opt-direct-cols baseline)

**Accuracy (the point):**
| config | baseline | QR |
|---|---|---|
| near-optimum saturate dim=50 | NaN | 0.000e+00 |
| near-optimum saturate dim=200 | NaN | 0.000e+00 |
| near-optimum mem=20 tail | NaN | 0.000e+00 |
| near-optimum mem=50 tail | NaN | 0.000e+00 |
| near-optimum type-I saturate | NaN | 0.000e+00 |
| near-optimum no-reg saturate | NaN | 0.000e+00 |
| scan:cond kappa=1e8 | 3.920e-3 | 1.249e-3 (3× tighter) |
| noisy no-reg (a_rej count) | 120 | 10 |
| saturate dim=200 (a_rej count) | 1151 | 183 |

All other configs within baseline run-to-run variation.

**Latency (the cost):**
| sweep | slowdown |
|---|---|
| scan:dim dim=500 mem=10 (canonical) | ~5× |
| scan:dim dim=20000 mem=10 | ~15× |
| scan:mem mem=1 | ~1× (no change) |
| scan:mem mem=100 | ~10× |

Cost is O(dim · mem²) vs prior O(dim · mem). Accepted tradeoff.

## Tests

New stress tests:
- `test_post_convergence_stays_finite` — 2000-iter run past saturation
- `test_zero_reg_near_singular_y` — regularization=0 + saturation
- `test_ill_conditioned_gd` — κ(Q) = 1e10, must converge below 1e-2

All pre-existing tests pass unchanged.

## Test plan
- [x] `make test` on macOS (Apple LAPACK) — all pass
- [x] `tests/c/check_gd_convergence.sh` — passes
- [x] 5-run median benchmark comparison — see table above
- [ ] Verify on Linux + OpenBLAS in CI
- [ ] Verify across Python 3.9–3.14 matrix in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)