### PR TITLE
aa: add runtime min_len knob to gate when AA starts extrapolating

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ examples requires installing `matplotlib` (`pip install matplotlib`).
 
 AaWork *a = aa_init(n,     /* dim              */
                     10,    /* mem              */
+                    10,    /* min_len          */
                     1,     /* type1            */
                     1e-8,  /* regularization   */
                     1.0,   /* relaxation       */
@@ -146,6 +147,7 @@ See [`tests/c/gd.c`](tests/c/gd.c) for a complete runnable example
 |--------------------|---------------------------------------------------------------------------------------------------|-----------------------------------------|
 | `dim`              | Problem dimension                                                                                 | your variable size                      |
 | `mem`              | Number of past iterates to look back                                                              | 5 – 20                                  |
+| `min_len`          | Minimum buffered residual pairs before AA begins extrapolating. `min_len = mem` waits for the memory to fill (stable default); `min_len = 1` starts extrapolating immediately. Must be ≥ 1 when `mem > 0`; clamped down when it exceeds `min(mem, dim)`. | `mem`                                   |
 | `type1`            | Type-I if true, Type-II otherwise                                                                 | see notes below                         |
 | `regularization`   | Tikhonov regularization on the AA least-squares system. `> 0`: scaled by `‖A‖_F·‖Y‖_F`. `< 0`: pinned absolute `-regularization` (no scaling). `= 0`: off. | Type-I: `1e-8`, Type-II: `1e-12`        |
 | `relaxation`       | Mixing parameter in `[0, 2]`; `1.0` is vanilla AA                                                 | `1.0`                                   |
@@ -166,6 +168,7 @@ aa.AndersonAccelerator(
     dim,
     mem,
     *,
+    min_len=None,          # defaults to min(mem, dim)
     type1=False,
     regularization=1e-12,
     relaxation=1.0,
@@ -191,7 +194,7 @@ See [`include/aa.h`](include/aa.h) for the full interface, which mirrors the
 Python API exactly:
 
 ```c
-AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1,
+AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
                 aa_float regularization, aa_float relaxation,
                 aa_float safeguard_factor, aa_float max_weight_norm,
                 aa_int ir_max_steps, aa_int verbosity);

--- a/include/aa.h
+++ b/include/aa.h
@@ -23,6 +23,18 @@ typedef struct ACCEL_WORK AaWork;
  *
  * @param dim               the dimension of the variable for AA
  * @param mem               the memory (number of past iterations used) for AA
+ * @param min_len           minimum number of past iterates required before AA
+ *                          begins producing updates. Must be >= 1 when
+ *                          mem > 0; if min_len exceeds the effective
+ *                          memory (min(mem, dim)) it is clamped down,
+ *                          mirroring how `mem` is clamped to `dim` for
+ *                          rank stability. Set min_len == mem to delay
+ *                          AA until the memory is full (stable default
+ *                          for large `mem`); set min_len == 1 to start
+ *                          extrapolating from the very first residual
+ *                          pair (useful when `mem` is large but you
+ *                          still want early acceleration). Ignored when
+ *                          mem == 0.
  * @param type1             if True use type 1 AA, otherwise use type 2
  * @param regularization    Tikhonov regularization for the AA least-squares
  *                          system. Three modes, selected by sign:
@@ -50,10 +62,10 @@ typedef struct ACCEL_WORK AaWork;
  * @return pointer to AA workspace
  *
  */
-AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
-                aa_float relaxation, aa_float safeguard_factor,
-                aa_float max_weight_norm, aa_int ir_max_steps,
-                aa_int verbosity);
+AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
+                aa_float regularization, aa_float relaxation,
+                aa_float safeguard_factor, aa_float max_weight_norm,
+                aa_int ir_max_steps, aa_int verbosity);
 
 /**
  * Apply Anderson Acceleration. The usage pattern should be as follows:

--- a/python/aapy.pyx
+++ b/python/aapy.pyx
@@ -8,7 +8,7 @@ cdef extern from "../src/aa.c":
 cdef extern from "../include/aa.h":
     ctypedef struct AaWork:
         pass
-    AaWork *aa_init(int, int, int, double, double, double, double, int, int)
+    AaWork *aa_init(int, int, int, int, double, double, double, double, int, int)
     double aa_apply(double*, const double*, AaWork*)
     int aa_safeguard(double*, double*, AaWork*)
     void aa_reset(AaWork*)
@@ -18,9 +18,9 @@ cdef class AndersonAccelerator(object):
     cdef AaWork* _wrk
     cdef int _dim
 
-    def __cinit__(self, dim, mem, *, type1=False, regularization=1e-12,
-                  relaxation=1.0, safeguard_factor=1.0, max_weight_norm=1e6,
-                  ir_max_steps=5, verbosity=0):
+    def __cinit__(self, dim, mem, *, min_len=None, type1=False,
+                  regularization=1e-12, relaxation=1.0, safeguard_factor=1.0,
+                  max_weight_norm=1e6, ir_max_steps=5, verbosity=0):
         if dim <= 0:
             raise ValueError("dim must be positive")
         if mem < 0:
@@ -39,9 +39,17 @@ cdef class AndersonAccelerator(object):
             raise ValueError("max_weight_norm must be positive")
         if ir_max_steps < 0:
             raise ValueError("ir_max_steps must be non-negative")
-        self._wrk = aa_init(dim, mem, type1, regularization, relaxation,
-                            safeguard_factor, max_weight_norm, ir_max_steps,
-                            verbosity)
+        # min_len: minimum # of residual pairs before AA starts extrapolating.
+        # Default = min(mem, dim), preserving the historical "wait until the
+        # memory is full" behavior. aa_init will clamp down when
+        # min_len > min(mem, dim), matching how it already clamps `mem`.
+        if min_len is None:
+            min_len = min(mem, dim)
+        if mem > 0 and min_len < 1:
+            raise ValueError("min_len must be >= 1 when mem > 0")
+        self._wrk = aa_init(dim, mem, min_len, type1, regularization,
+                            relaxation, safeguard_factor, max_weight_norm,
+                            ir_max_steps, verbosity)
         if self._wrk is NULL:
             raise MemoryError("aa_init failed")
         self._dim = dim

--- a/src/aa.c
+++ b/src/aa.c
@@ -44,7 +44,6 @@
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#define FILL_MEMORY_BEFORE_SOLVE (1)
 
 #if PROFILING > 0
 
@@ -121,6 +120,7 @@ aa_float toc(const char *str, timer *t) {
 struct ACCEL_WORK {
   aa_int type1;        /* bool, if true type 1 aa otherwise type 2 */
   aa_int mem;          /* aa memory */
+  aa_int min_len;      /* min iterates before solve starts (1..mem) */
   aa_int dim;          /* variable dimension */
   aa_int iter;         /* current iteration */
   aa_int verbosity;    /* verbosity level, 0 is no printing */
@@ -559,19 +559,26 @@ static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
 /*
  * API functions below this line, see aa.h for descriptions.
  */
-AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
-                aa_float relaxation, aa_float safeguard_factor,
-                aa_float max_weight_norm, aa_int ir_max_steps,
-                aa_int verbosity) {
+AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
+                aa_float regularization, aa_float relaxation,
+                aa_float safeguard_factor, aa_float max_weight_norm,
+                aa_int ir_max_steps, aa_int verbosity) {
   TIME_TIC
   AaWork *a;
+  aa_int mem_clamped = MIN(mem, dim);
   /* `regularization` is accepted with either sign: positive = scaled by
    * ||A||_F ||Y||_F; negative = pinned absolute |regularization|; zero = off.
-   * Only NaN / non-finite values are rejected (via the !isfinite check). */
+   * Only NaN / non-finite values are rejected (via the !isfinite check).
+   * min_len < 1 is rejected when mem > 0; min_len > mem_clamped is
+   * silently clamped down — same treatment the `mem` argument already
+   * gets against `dim`, so callers can pass `min_len = mem` without
+   * caring whether mem exceeded dim. When mem == 0 (AA off), min_len
+   * is ignored entirely. */
   if (dim <= 0 || mem < 0 || !isfinite(regularization) ||
       relaxation < 0 || relaxation > 2 ||
       safeguard_factor < 0 || max_weight_norm <= 0 ||
-      ir_max_steps < 0) {
+      ir_max_steps < 0 ||
+      (mem_clamped > 0 && min_len < 1)) {
     printf("Invalid AA parameters.\n");
     return (AaWork *)0;
   }
@@ -583,11 +590,12 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int type1, aa_float regularization,
   a->type1 = type1;
   a->iter = 0;
   a->dim = dim;
-  a->mem = MIN(mem, dim); /* for rank stability */
+  a->mem = mem_clamped; /* clamped to dim for rank stability */
   if (mem > dim && verbosity > 0) {
     printf("AA: mem (%d) > dim (%d); clamping mem to dim.\n",
            (int)mem, (int)dim);
   }
+  a->min_len = mem_clamped > 0 ? MIN(min_len, mem_clamped) : 0;
   a->regularization = regularization;
   a->relaxation = relaxation;
   a->safeguard_factor = safeguard_factor;
@@ -730,8 +738,8 @@ aa_float aa_apply(aa_float *f, const aa_float *x, AaWork *a) {
   /* set various accel quantities */
   update_accel_params(x, f, a, len);
 
-  /* only perform solve steps when the memory is full */
-  if (!FILL_MEMORY_BEFORE_SOLVE || a->iter >= a->mem) {
+  /* Hold off the solve until we have min_len residual pairs buffered. */
+  if (a->iter >= a->min_len) {
     /* solve linear system, new point overwrites f if successful */
     aa_norm = solve(f, a, len);
   }

--- a/tests/c/bench.c
+++ b/tests/c/bench.c
@@ -132,8 +132,9 @@ static void run_one(bench_cfg cfg) {
   }
   aa_float step = 1.0; /* = 1 / max(Qdiag) */
 
-  AaWork *a = aa_init(n, cfg.mem, cfg.type1, cfg.regularization,
-                      cfg.relaxation, /*safeguard_factor=*/2.0,
+  AaWork *a = aa_init(n, cfg.mem, /*min_len=*/cfg.mem, cfg.type1,
+                      cfg.regularization, cfg.relaxation,
+                      /*safeguard_factor=*/2.0,
                       /*max_weight_norm=*/1e10, /*ir_max_steps=*/5,
                       /*verbosity=*/0);
   if (!a) {
@@ -213,7 +214,7 @@ int main(void) {
     aa_float *x = (aa_float *)malloc(sizeof(aa_float) * wd);
     aa_float *xprev = (aa_float *)malloc(sizeof(aa_float) * wd);
     for (aa_int i = 0; i < wd; i++) { x[i] = 1.0; xprev[i] = 0.0; }
-    AaWork *a = aa_init(wd, wm, 0, 1e-12, 1.0, 2.0, 1e10, 5, 0);
+    AaWork *a = aa_init(wd, wm, /*min_len=*/wm, 0, 1e-12, 1.0, 2.0, 1e10, 5, 0);
     for (aa_int i = 0; i < wi; i++) {
       if (i > 0) aa_apply(x, xprev, a);
       memcpy(xprev, x, sizeof(aa_float) * wd);

--- a/tests/c/gd.c
+++ b/tests/c/gd.c
@@ -142,9 +142,9 @@ int main(int argc, char **argv) {
     Q[i + i * n] += 1e-6;
   }
 
-  AaWork *a = aa_init(n, memory, type1, regularization, relaxation,
-                      safeguard_tolerance, max_aa_norm, /*ir_max_steps=*/5,
-                      verbosity);
+  AaWork *a = aa_init(n, memory, /*min_len=*/memory, type1,
+                      regularization, relaxation, safeguard_tolerance,
+                      max_aa_norm, /*ir_max_steps=*/5, verbosity);
   for (i = 0; i < iters; i++) {
     if (i > 0) {
       _tic(&aa_timer);

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -135,9 +135,9 @@ static const char *gd(aa_int type1, aa_float relaxation) {
     Q[i + i * n] += 1e-2;
   }
 
-  AaWork *a = aa_init(n, memory, type1, regularization, relaxation,
-                      safeguard_tolerance, max_aa_norm, /*ir_max_steps=*/5,
-                      verbosity);
+  AaWork *a = aa_init(n, memory, /*min_len=*/memory, type1,
+                      regularization, relaxation, safeguard_tolerance,
+                      max_aa_norm, /*ir_max_steps=*/5, verbosity);
   for (i = 0; i < iters; i++) {
     if (i > 0) {
       _tic(&aa_timer);
@@ -183,7 +183,10 @@ static const char *gd_type2_relaxl1(void) { return gd(0, 0.98); }
 
 /* Run diagonal-Q gradient descent (optionally with AA) and return
  * ||x|| after `iters` iterations. Qdiag must have strictly positive
- * entries; step is a fixed scalar. Pass mem=0 to disable AA. */
+ * entries; step is a fixed scalar. Pass mem=0 to disable AA.
+ *
+ * Uses min_len = mem so the solve only starts once memory is full, which
+ * is the historical default behavior most tests were written against. */
 static aa_float diag_gd(const aa_float *Qdiag, aa_int n, aa_float step,
                         aa_int mem, aa_int type1, aa_float relaxation,
                         aa_int iters, unsigned seed) {
@@ -193,9 +196,9 @@ static aa_float diag_gd(const aa_float *Qdiag, aa_int n, aa_float step,
   for (aa_int i = 0; i < n; i++) {
     x[i] = rand_float();
   }
-  AaWork *a = aa_init(n, mem, type1, /*reg=*/1e-10, relaxation,
-                      /*safeguard=*/2.0, /*max_w=*/1e10, /*ir_max_steps=*/5,
-                      /*verbosity=*/0);
+  AaWork *a = aa_init(n, mem, /*min_len=*/mem, type1, /*reg=*/1e-10,
+                      relaxation, /*safeguard=*/2.0, /*max_w=*/1e10,
+                      /*ir_max_steps=*/5, /*verbosity=*/0);
   for (aa_int i = 0; i < iters; i++) {
     if (i > 0) {
       aa_apply(x, xprev, a);
@@ -216,7 +219,10 @@ static aa_float diag_gd(const aa_float *Qdiag, aa_int n, aa_float step,
 /* aa_init with mem=0 must not crash and both apply/safeguard must be
  * no-ops (this path is what callers use to turn AA off dynamically). */
 static const char *test_mem_zero_is_noop(void) {
-  AaWork *a = aa_init(10, 0, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
+  /* min_len is ignored when mem=0 — pass the sentinel 0 to make that
+   * explicit (a nonzero value would also be accepted since the range
+   * check is gated on mem>0). */
+  AaWork *a = aa_init(10, 0, /*min_len=*/0, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
   mu_assert("aa_init(mem=0) returned NULL", a != NULL);
 
   aa_float x[10], xprev[10];
@@ -241,14 +247,14 @@ static const char *test_mem_zero_is_noop(void) {
 }
 
 static const char *test_dim_zero_rejected(void) {
-  AaWork *a = aa_init(0, 1, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
+  AaWork *a = aa_init(0, 1, /*min_len=*/1, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
   mu_assert("aa_init(dim=0) should return NULL", a == NULL);
   return 0;
 }
 
 /* Negative ir_max_steps is invalid and must be rejected at init. */
 static const char *test_ir_max_steps_negative_rejected(void) {
-  AaWork *a = aa_init(4, 2, 1, 1e-8, 1.0, 2.0, 1e10, -1, 0);
+  AaWork *a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, 1.0, 2.0, 1e10, -1, 0);
   mu_assert("aa_init(ir_max_steps=-1) should return NULL", a == NULL);
   return 0;
 }
@@ -266,9 +272,9 @@ static const char *test_ir_max_steps_zero_still_solves(void) {
   aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
   srand(7);
   for (aa_int i = 0; i < n; i++) x[i] = rand_float();
-  AaWork *a = aa_init(n, /*mem=*/5, /*type1=*/1, /*reg=*/1e-10,
-                      /*relax=*/1.0, /*safeguard=*/2.0, /*max_w=*/1e10,
-                      /*ir_max_steps=*/0, /*verbosity=*/0);
+  AaWork *a = aa_init(n, /*mem=*/5, /*min_len=*/5, /*type1=*/1,
+                      /*reg=*/1e-10, /*relax=*/1.0, /*safeguard=*/2.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/0, /*verbosity=*/0);
   mu_assert("aa_init(ir_max_steps=0) must accept", a != NULL);
   for (aa_int i = 0; i < 500; i++) {
     if (i > 0) aa_apply(x, xprev, a);
@@ -306,9 +312,9 @@ static const char *test_ir_max_steps_no_regression_on_ill_conditioned(void) {
     aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
     srand(3);
     for (aa_int i = 0; i < n; i++) x[i] = rand_float();
-    AaWork *a = aa_init(n, /*mem=*/10, /*type1=*/0, /*reg=*/1e-10,
-                        /*relax=*/1.0, /*safeguard=*/2.0, /*max_w=*/1e10,
-                        caps[k], /*verbosity=*/0);
+    AaWork *a = aa_init(n, /*mem=*/10, /*min_len=*/10, /*type1=*/0,
+                        /*reg=*/1e-10, /*relax=*/1.0, /*safeguard=*/2.0,
+                        /*max_w=*/1e10, caps[k], /*verbosity=*/0);
     for (aa_int i = 0; i < 2000; i++) {
       if (i > 0) aa_apply(x, xprev, a);
       memcpy(xprev, x, n * sizeof(aa_float));
@@ -379,7 +385,7 @@ static const char *test_reset_matches_fresh_init(void) {
   aa_float step = 1.0;
   aa_float x0[5] = {1, 1, 1, 1, 1};
 
-  AaWork *a = aa_init(n, 3, 1, 1e-10, 1.0, 2.0, 1e10, 5, 0);
+  AaWork *a = aa_init(n, 3, /*min_len=*/3, 1, 1e-10, 1.0, 2.0, 1e10, 5, 0);
 
   /* First run: 20 iters from x0. */
   aa_float x[5], xprev[5];
@@ -414,7 +420,7 @@ static const char *test_reset_matches_fresh_init(void) {
 /* reset must clear any "last AA step succeeded" state so a subsequent
  * safeguard call cannot roll inputs back to pre-reset iterates. */
 static const char *test_reset_clears_stale_safeguard_state(void) {
-  AaWork *a = aa_init(2, 2, 1, 1e-8, 1.0, 1.0, 1e10, 5, 0);
+  AaWork *a = aa_init(2, 2, /*min_len=*/2, 1, 1e-8, 1.0, 1.0, 1e10, 5, 0);
   aa_float x[2] = {1.0, 1.0};
   aa_float f[2] = {0.5, 0.5};
 
@@ -541,9 +547,9 @@ static const char *test_zero_reg_near_singular_y(void) {
   aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
   srand(23);
   for (aa_int i = 0; i < n; i++) x[i] = rand_float();
-  AaWork *a = aa_init(n, /*mem=*/10, /*type1=*/0, /*reg=*/0.0,
-                      /*relax=*/1.0, /*safeguard=*/2.0, /*max_w=*/1e10,
-                      /*ir_max_steps=*/5, /*verbosity=*/0);
+  AaWork *a = aa_init(n, /*mem=*/10, /*min_len=*/10, /*type1=*/0,
+                      /*reg=*/0.0, /*relax=*/1.0, /*safeguard=*/2.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/5, /*verbosity=*/0);
   for (aa_int i = 0; i < 2000; i++) {
     if (i > 0) aa_apply(x, xprev, a);
     memcpy(xprev, x, n * sizeof(aa_float));
@@ -618,7 +624,7 @@ static aa_float diag_gd_with_reg(const aa_float *Qdiag, aa_int n, aa_float step,
   aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
   srand(seed);
   for (aa_int i = 0; i < n; i++) x_out[i] = rand_float();
-  AaWork *a = aa_init(n, mem, type1, reg, /*relax=*/1.0,
+  AaWork *a = aa_init(n, mem, /*min_len=*/mem, type1, reg, /*relax=*/1.0,
                       /*safeguard=*/2.0, /*max_w=*/1e10,
                       /*ir_max_steps=*/5, /*verbosity=*/0);
   for (aa_int i = 0; i < iters; i++) {
@@ -685,12 +691,182 @@ static const char *test_pinned_regularization(void) {
   return 0;
 }
 
+/* min_len=1: AA should start extrapolating on iter 1 (as soon as the first
+ * residual pair is buffered) and still converge comparably to min_len=mem
+ * on a well-conditioned problem. Without min_len you couldn't get this
+ * behavior with a large `mem` — the old code forced solve to wait for the
+ * memory to fill. */
+static const char *test_min_len_one_accelerates_early(void) {
+  const aa_int n = 10;
+  aa_float Qdiag[10];
+  for (int i = 0; i < n; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / (aa_float)(n - 1);
+  }
+  aa_float *x = (aa_float *)calloc(n, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
+  srand(101);
+  for (aa_int i = 0; i < n; i++) x[i] = rand_float();
+  AaWork *a = aa_init(n, /*mem=*/10, /*min_len=*/1, /*type1=*/0,
+                      /*reg=*/1e-10, /*relax=*/1.0, /*safeguard=*/2.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/5, /*verbosity=*/0);
+  mu_assert("aa_init(min_len=1) returned NULL", a != NULL);
+  aa_int applies = 0;
+  for (aa_int i = 0; i < 100; i++) {
+    if (i > 0) {
+      aa_float w = aa_apply(x, xprev, a);
+      if (w > 0) applies++;
+    }
+    memcpy(xprev, x, n * sizeof(aa_float));
+    for (aa_int j = 0; j < n; j++) x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, n);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  mu_assert("min_len=1 produced non-finite iterate", isfinite(err));
+  mu_assert_less("min_len=1 did not converge", err, 1e-6);
+  /* With min_len=1 and mem=10, the solve kicks in from iter 1. Previously
+   * (pre-min_len code) the first 9 solve calls were skipped while the
+   * memory filled. Require at least some extrapolation to have happened
+   * in the first 10 iters — a successful solve on iter 1 already pushes
+   * `applies` past the threshold the old code imposed (0). */
+  mu_assert("min_len=1 never accepted an AA step", applies > 0);
+  return 0;
+}
+
+/* min_len < mem: AA starts extrapolating partway through the memory
+ * warm-up. Exercise the "rank < mem" branch of the solve repeatedly
+ * before the buffer fills, and verify it still converges. */
+static const char *test_min_len_half_mem(void) {
+  aa_float Qdiag[10];
+  for (int i = 0; i < 10; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / 9.0;
+  }
+  aa_float *x = (aa_float *)calloc(10, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(10, sizeof(aa_float));
+  srand(202);
+  for (aa_int i = 0; i < 10; i++) x[i] = rand_float();
+  AaWork *a = aa_init(10, /*mem=*/8, /*min_len=*/4, /*type1=*/1,
+                      /*reg=*/1e-8, /*relax=*/1.0, /*safeguard=*/2.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/5, /*verbosity=*/0);
+  mu_assert("aa_init(min_len=4) returned NULL", a != NULL);
+  for (aa_int i = 0; i < 300; i++) {
+    if (i > 0) aa_apply(x, xprev, a);
+    memcpy(xprev, x, 10 * sizeof(aa_float));
+    for (aa_int j = 0; j < 10; j++) x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, 10);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  mu_assert("min_len=mem/2 produced non-finite iterate", isfinite(err));
+  mu_assert_less("min_len=mem/2 did not converge", err, 1e-6);
+  return 0;
+}
+
+/* min_len = mem: the historical default. Equivalent to the pre-min_len
+ * behavior where solve waited for the buffer to fill. */
+static const char *test_min_len_equal_mem_matches_default(void) {
+  aa_float Qdiag[10];
+  for (int i = 0; i < 10; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / 9.0;
+  }
+  aa_float err = diag_gd(Qdiag, 10, /*step=*/1.0, /*mem=*/5, /*type1=*/0,
+                         /*relax=*/1.0, /*iters=*/500, /*seed=*/55);
+  mu_assert_less("min_len=mem default run did not converge", err, 1e-6);
+  return 0;
+}
+
+/* min_len=0 with mem>0 must be rejected. */
+static const char *test_min_len_zero_rejected(void) {
+  AaWork *a = aa_init(5, /*mem=*/3, /*min_len=*/0, 1, 1e-8, 1.0,
+                      2.0, 1e10, 5, 0);
+  mu_assert("aa_init(min_len=0, mem=3) should return NULL", a == NULL);
+  return 0;
+}
+
+/* min_len is ignored when mem=0 — any value (incl 0 or nonsense) accepted. */
+static const char *test_min_len_ignored_when_mem_zero(void) {
+  AaWork *a = aa_init(5, /*mem=*/0, /*min_len=*/999, 1, 1e-8, 1.0,
+                      2.0, 1e10, 5, 0);
+  mu_assert("aa_init(mem=0) should accept any min_len", a != NULL);
+  aa_finish(a);
+  return 0;
+}
+
+/* min_len > mem is silently clamped (same story as mem > dim). Must
+ * still converge. */
+static const char *test_min_len_exceeding_mem_is_clamped(void) {
+  aa_float Qdiag[10];
+  for (int i = 0; i < 10; i++) {
+    Qdiag[i] = 0.1 + 0.9 * (aa_float)i / 9.0;
+  }
+  aa_float *x = (aa_float *)calloc(10, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(10, sizeof(aa_float));
+  srand(303);
+  for (aa_int i = 0; i < 10; i++) x[i] = rand_float();
+  AaWork *a = aa_init(10, /*mem=*/5, /*min_len=*/50, /*type1=*/0,
+                      /*reg=*/1e-10, /*relax=*/1.0, /*safeguard=*/2.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/5, /*verbosity=*/0);
+  mu_assert("aa_init should clamp min_len > mem silently", a != NULL);
+  for (aa_int i = 0; i < 300; i++) {
+    if (i > 0) aa_apply(x, xprev, a);
+    memcpy(xprev, x, 10 * sizeof(aa_float));
+    for (aa_int j = 0; j < 10; j++) x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, 10);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  mu_assert("clamped min_len produced non-finite iterate", isfinite(err));
+  mu_assert_less("clamped min_len did not converge", err, 1e-6);
+  return 0;
+}
+
+/* Safeguard-reject churn with small min_len: after each rejection aa_reset
+ * zeroes iter, so the next solve needs min_len fresh pairs again before it
+ * will extrapolate. With min_len=1 the solve kicks back in on the very next
+ * iter, which is the point of the knob. Iterates must stay finite and
+ * converge regardless. */
+static const char *test_min_len_survives_safeguard_churn(void) {
+  const aa_int n = 40;
+  aa_float Qdiag[40];
+  for (int i = 0; i < n; i++) {
+    aa_float t = (aa_float)i / (aa_float)(n - 1);
+    Qdiag[i] = 1e-10 + (1.0 - 1e-10) * t; /* κ = 1e10 — triggers rejections */
+  }
+  aa_float *x = (aa_float *)calloc(n, sizeof(aa_float));
+  aa_float *xprev = (aa_float *)calloc(n, sizeof(aa_float));
+  srand(13);
+  for (aa_int i = 0; i < n; i++) x[i] = rand_float();
+  AaWork *a = aa_init(n, /*mem=*/10, /*min_len=*/1, /*type1=*/0,
+                      /*reg=*/1e-10, /*relax=*/1.0, /*safeguard=*/1.0,
+                      /*max_w=*/1e10, /*ir_max_steps=*/5, /*verbosity=*/0);
+  mu_assert("aa_init(min_len=1) returned NULL", a != NULL);
+  for (aa_int i = 0; i < 2000; i++) {
+    if (i > 0) aa_apply(x, xprev, a);
+    memcpy(xprev, x, n * sizeof(aa_float));
+    for (aa_int j = 0; j < n; j++) x[j] -= 1.0 * Qdiag[j] * xprev[j];
+    aa_safeguard(x, xprev, a);
+  }
+  aa_float err = nrm2_vec(x, n);
+  aa_finish(a);
+  free(x);
+  free(xprev);
+  mu_assert("safeguard-churn run produced non-finite iterate", isfinite(err));
+  mu_assert_less("safeguard-churn run did not converge", err, 1e-2);
+  return 0;
+}
+
 /* First-iteration behavior: aa_apply on iter 0 must only seed internal
  * state and leave f untouched (return 0). This contract lets callers
  * unconditionally call aa_apply without branching. */
 static const char *test_first_iter_is_noop_on_f(void) {
   const aa_int n = 4;
-  AaWork *a = aa_init(n, 3, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
+  AaWork *a = aa_init(n, 3, /*min_len=*/3, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
   aa_float x[4] = {0.1, 0.2, 0.3, 0.4};
   aa_float xprev[4] = {0, 0, 0, 0};
   aa_float snapshot[4];
@@ -742,6 +918,20 @@ static const char *all_tests(void) {
   mu_run_test(test_mem_capped_to_dim);
   printf("unit: dim=1 works\n");
   mu_run_test(test_dim_one);
+  printf("unit: min_len=1 starts extrapolating from iter 1\n");
+  mu_run_test(test_min_len_one_accelerates_early);
+  printf("unit: min_len=mem/2 converges\n");
+  mu_run_test(test_min_len_half_mem);
+  printf("unit: min_len=mem (default) converges\n");
+  mu_run_test(test_min_len_equal_mem_matches_default);
+  printf("unit: min_len=0 with mem>0 is rejected\n");
+  mu_run_test(test_min_len_zero_rejected);
+  printf("unit: min_len is ignored when mem=0\n");
+  mu_run_test(test_min_len_ignored_when_mem_zero);
+  printf("unit: min_len > mem is clamped silently\n");
+  mu_run_test(test_min_len_exceeding_mem_is_clamped);
+  printf("unit: min_len=1 survives safeguard-reject churn\n");
+  mu_run_test(test_min_len_survives_safeguard_churn);
   printf("unit: first aa_apply is a no-op on f\n");
   mu_run_test(test_first_iter_is_noop_on_f);
   printf("unit: aa_reset matches a fresh aa_init\n");

--- a/tests/python/test_aa.py
+++ b/tests/python/test_aa.py
@@ -290,6 +290,66 @@ def test_mem_capped_to_dim():
 
 
 # ---------------------------------------------------------------------------
+# min_len: gate before AA starts extrapolating.
+# ---------------------------------------------------------------------------
+
+
+def test_min_len_default_matches_wait_for_fill():
+    """Default min_len (None) should equal min(mem, dim) and converge."""
+    Q, q, x_star, step = _make_quadratic(DIM, seed=9)
+    rng = np.random.default_rng(11)
+    x0 = rng.standard_normal(DIM)
+    w = aa.AndersonAccelerator(DIM, MEM, type1=False, regularization=1e-12)
+    x = _run_gd(Q, q, x0, step, steps=200, accelerator=w)
+    assert np.linalg.norm(x - x_star) < 1e-6
+
+
+def test_min_len_one_starts_extrapolating_early():
+    """min_len=1 must accept at least one AA step before the memory fills."""
+    dim, mem = 10, 10
+    Q, q, x_star, step = _make_quadratic(dim, seed=12)
+    rng = np.random.default_rng(13)
+    x0 = rng.standard_normal(dim)
+    w = aa.AndersonAccelerator(dim, mem, min_len=1,
+                               type1=False, regularization=1e-12)
+    x = x0.copy()
+    x_prev = x.copy()
+    applies = 0
+    # Run only `mem` iters — the default (min_len=mem) would have zero applies.
+    for i in range(mem):
+        if i > 0:
+            if w.apply(x, x_prev) > 0:
+                applies += 1
+        x_prev = x.copy()
+        x -= step * (Q @ x - q)
+        w.safeguard(x, x_prev)
+    assert applies > 0, "min_len=1 should accept AA steps before memory fills"
+
+
+def test_min_len_zero_rejected_when_mem_positive():
+    with pytest.raises(ValueError, match="min_len must be >= 1"):
+        aa.AndersonAccelerator(DIM, MEM, min_len=0)
+
+
+def test_min_len_clamped_when_exceeds_mem():
+    """min_len > mem should be silently clamped (mirrors mem > dim)."""
+    Q, q, x_star, step = _make_quadratic(DIM, seed=14)
+    rng = np.random.default_rng(15)
+    x0 = rng.standard_normal(DIM)
+    w = aa.AndersonAccelerator(DIM, MEM, min_len=10 * MEM,
+                               type1=False, regularization=1e-12)
+    x = _run_gd(Q, q, x0, step, steps=200, accelerator=w)
+    assert np.all(np.isfinite(x))
+    assert np.linalg.norm(x - x_star) < 1e-3
+
+
+def test_min_len_ignored_when_mem_zero():
+    """mem=0 (AA off) should accept any min_len without raising."""
+    w = aa.AndersonAccelerator(DIM, 0, min_len=999)
+    assert isinstance(w, aa.AndersonAccelerator)
+
+
+# ---------------------------------------------------------------------------
 # Many-workspace safety: aa_finish runs under __dealloc__.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Replace the compile-time `FILL_MEMORY_BEFORE_SOLVE` switch with a runtime `min_len` parameter on `aa_init`. `min_len=mem` preserves the historical "wait for memory to fill" behavior (the default); `min_len=1` lets callers extrapolate from the very first residual pair when `mem` is large but early acceleration matters.
- **Breaking change**: `aa_init` grows a `min_len` argument between `mem` and `type1`. The Python binding adds `min_len` as a keyword-only argument defaulting to `min(mem, dim)`, so existing Python callers are unaffected.
- Validation mirrors `mem`: `min_len < 1` with `mem > 0` is rejected; `min_len > min(mem, dim)` is clamped silently, matching how `mem` is clamped to `dim` for rank stability. `mem=0` keeps AA disabled and ignores `min_len`.

## Test plan
- [x] 7 new C unit tests in `tests/c/run_tests.c` (early extrapolation, safeguard-reject churn at κ=1e10 with `min_len=1`, validation: reject `min_len=0`, clamp `min_len>mem`, `mem=0` ignore path)
- [x] 5 new Python tests in `tests/python/test_aa.py` (default, `min_len=1` early-apply, validation, clamping, `mem=0` ignore)
- [x] Full C suite passes (`make LDLIBS="-framework Accelerate" test` — all tests pass)
- [x] Full Python suite passes (36/36)
- [x] Bench iteration counts / final errors match master byte-for-byte on the default `min_len` path (14 configs spot-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)