### PR TITLE
aa: make rank tolerance dim-independent (len·ε·|R₁₁|)

### DIFF
--- a/src/aa.c
+++ b/src/aa.c
@@ -348,12 +348,14 @@ static void relax(aa_float *f, AaWork *a, aa_int len) {
 /* Solve the regularized normal equations (A'B + rI) γ = A'g via a
  * pivoted QR (geqp3) of the augmented matrix [A; √r I]. Column pivoting
  * exposes the numerical rank directly in the diagonal of R: we truncate
- * at the first diagonal whose magnitude falls below aug_rows·ε·|R_11|
- * and solve the smaller, well-conditioned system (graceful degradation
- * instead of hard reset on near-rank-deficiency). Iterative refinement
- * on the reduced system recovers digits lost to gesv/trsv rounding; the
- * loop auto-stops when the correction no longer contracts and is capped
- * at ir_max_steps (see aa_init). γ is then validated against
+ * at the first diagonal whose magnitude falls below len·ε·|R_11|
+ * (dim-independent: the inner LS is a len-column problem, so its noise
+ * floor scales with column count, not the caller's state dim) and solve
+ * the smaller, well-conditioned system (graceful degradation instead of
+ * hard reset on near-rank-deficiency). Iterative refinement on the
+ * reduced system recovers digits lost to gesv/trsv rounding; the loop
+ * auto-stops when the correction no longer contracts and is capped at
+ * ir_max_steps (see aa_init). γ is then validated against
  * max_weight_norm in the L2 sense. */
 static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
   TIME_TIC
@@ -400,7 +402,12 @@ static aa_float solve(aa_float *f, AaWork *a, aa_int len) {
   if (info == 0) {
     aa_float r11 = fabs(a->A_aug[0]);
     if (r11 > 0) {
-      aa_float tol = r11 * (aa_float)aug_rows * AA_EPS;
+      /* Column-count-based rank tolerance: the effective LS problem has
+       * `len` columns, so the rounding floor for rank determination
+       * scales with `len`, not (dim + mem). Decoupling from `dim` avoids
+       * falsely dropping columns that are healthy relative to the
+       * regularizer at large state dimensions. */
+      aa_float tol = r11 * (aa_float)len * AA_EPS;
       for (rank = 0; rank < len; ++rank) {
         if (fabs(a->A_aug[rank * aug_rows + rank]) < tol) break;
       }


### PR DESCRIPTION
## Summary
- The pivoted-QR rank tolerance was `aug_rows·ε·|R₁₁|` with `aug_rows = dim + mem`, following LAPACK's `max(m,n)·ε·σ₁` convention. For AA this conflates two different dimensions: `dim` is the caller's state vector length, while the inner LS we're rank-revealing has only `len` columns (`len ≤ mem`, typically 5–20).
- Switching to `len·ε·|R₁₁|` decouples the tolerance from `dim`. Principled argument: the rank question is about the `len` columns of `[A; √r I_len]`; the tall `dim` rows are the caller's state, not part of the LS's algorithmic dimension.
- Practical consequence: at large state dim the old floor can exceed the noise floor the regularizer itself enforces. With `reg=1e-12` and `dim=1e6`, old tol ≈ 2e-10·|R₁₁| sits well above the √r floor (1e-6·|R₁₁|) that the augmented `√r·I` rows guarantee by construction — columns the regularizer certifies as healthy could be silently dropped.

## Test plan
- [x] Full C suite passes (`make LDLIBS="-framework Accelerate" test`)
- [x] Full Python suite passes (31/31)
- [x] Bench matches master byte-for-byte on all 14 configs (iter counts, applied/aa_rej/sg_rej, final_err) — at bench's dim range (50–2000) both tolerances are well below |R₁₁|, so no observable change, as expected. This is a large-dim robustness fix, not a perf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)