### PR TITLE
Reject non-finite AA scalar options

### DIFF
--- a/include/aa.h
+++ b/include/aa.h
@@ -46,10 +46,10 @@ typedef struct ACCEL_WORK AaWork;
  *                                  problem scale is known).
  *                            = 0 : no regularization.
  *                          Only non-finite values (NaN/Inf) are rejected.
- * @param relaxation        float \in [0,2], mixing parameter (1.0 is vanilla)
- * @param safeguard_factor  factor that controls safeguarding checks
+ * @param relaxation        finite float \in [0,2], mixing parameter (1.0 is vanilla)
+ * @param safeguard_factor  finite nonnegative factor that controls safeguarding checks
  *                          larger is more aggressive but less stable
- * @param max_weight_norm   float, maximum norm of AA weights
+ * @param max_weight_norm   finite positive float, maximum norm of AA weights
  * @param ir_max_steps      max iterative refinement passes on the γ solve.
  *                          0 disables IR. Each step is O(mem²) and loops
  *                          until the correction stops contracting, so on

--- a/python/aapy.pyx
+++ b/python/aapy.pyx
@@ -43,12 +43,12 @@ cdef class AndersonAccelerator(object):
         #   = 0  → off
         if not math.isfinite(regularization):
             raise ValueError("regularization must be finite")
-        if relaxation < 0 or relaxation > 2:
-            raise ValueError("relaxation must be in [0, 2]")
-        if safeguard_factor < 0:
-            raise ValueError("safeguard_factor must be non-negative")
-        if max_weight_norm <= 0:
-            raise ValueError("max_weight_norm must be positive")
+        if not math.isfinite(relaxation) or relaxation < 0 or relaxation > 2:
+            raise ValueError("relaxation must be finite and in [0, 2]")
+        if not math.isfinite(safeguard_factor) or safeguard_factor < 0:
+            raise ValueError("safeguard_factor must be finite and non-negative")
+        if not math.isfinite(max_weight_norm) or max_weight_norm <= 0:
+            raise ValueError("max_weight_norm must be finite and positive")
         if ir_max_steps < 0:
             raise ValueError("ir_max_steps must be non-negative")
         # min_len: minimum # of residual pairs before AA starts extrapolating.

--- a/src/aa.c
+++ b/src/aa.c
@@ -620,9 +620,11 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
    * gets against `dim`, so callers can pass `min_len = mem` without
    * caring whether mem exceeded dim. When mem == 0 (AA off), min_len
    * is ignored entirely. */
-  if (dim <= 0 || mem < 0 || !isfinite(regularization) ||
-      relaxation < 0 || relaxation > 2 ||
-      safeguard_factor < 0 || max_weight_norm <= 0 ||
+  if (dim <= 0 || mem < 0 ||
+      !isfinite(regularization) ||
+      !isfinite(relaxation) || relaxation < 0 || relaxation > 2 ||
+      !isfinite(safeguard_factor) || safeguard_factor < 0 ||
+      !isfinite(max_weight_norm) || max_weight_norm <= 0 ||
       ir_max_steps < 0 ||
       (mem_clamped > 0 && min_len < 1)) {
     printf("Invalid AA parameters.\n");

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -259,6 +259,29 @@ static const char *test_ir_max_steps_negative_rejected(void) {
   return 0;
 }
 
+/* Non-finite scalar options must be rejected. NaN is especially easy to
+ * miss because comparisons like `relaxation < 0` are false for NaN. */
+static const char *test_nonfinite_scalar_options_rejected(void) {
+  AaWork *a;
+
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, NAN, 2.0, 1e10, 5, 0);
+  mu_assert("aa_init(relaxation=NaN) should return NULL", a == NULL);
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, INFINITY, 2.0, 1e10, 5, 0);
+  mu_assert("aa_init(relaxation=Inf) should return NULL", a == NULL);
+
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, 1.0, NAN, 1e10, 5, 0);
+  mu_assert("aa_init(safeguard_factor=NaN) should return NULL", a == NULL);
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, 1.0, INFINITY, 1e10, 5, 0);
+  mu_assert("aa_init(safeguard_factor=Inf) should return NULL", a == NULL);
+
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, 1.0, 2.0, NAN, 5, 0);
+  mu_assert("aa_init(max_weight_norm=NaN) should return NULL", a == NULL);
+  a = aa_init(4, 2, /*min_len=*/2, 1, 1e-8, 1.0, 2.0, INFINITY, 5, 0);
+  mu_assert("aa_init(max_weight_norm=Inf) should return NULL", a == NULL);
+
+  return 0;
+}
+
 /* ir_max_steps=0 disables iterative refinement entirely. The solve
  * path still runs end-to-end and AA still converges on an easy
  * well-conditioned problem. */
@@ -1009,6 +1032,8 @@ static const char *all_tests(void) {
   mu_run_test(test_dim_zero_rejected);
   printf("unit: negative ir_max_steps is rejected\n");
   mu_run_test(test_ir_max_steps_negative_rejected);
+  printf("unit: non-finite scalar options are rejected\n");
+  mu_run_test(test_nonfinite_scalar_options_rejected);
   printf("unit: ir_max_steps=0 (IR disabled) still solves\n");
   mu_run_test(test_ir_max_steps_zero_still_solves);
   printf("unit: ir_max_steps variants both converge on ill-conditioned GD\n");

--- a/tests/python/test_aa.py
+++ b/tests/python/test_aa.py
@@ -93,9 +93,15 @@ def test_construct_dim_one():
         (dict(dim=DIM, mem=-1), "mem must be non-negative"),
         (dict(dim=DIM, mem=MEM, regularization=float("nan")), "regularization must be finite"),
         (dict(dim=DIM, mem=MEM, regularization=float("inf")), "regularization must be finite"),
-        (dict(dim=DIM, mem=MEM, relaxation=3.0), "relaxation must be in \\[0, 2\\]"),
-        (dict(dim=DIM, mem=MEM, safeguard_factor=-1.0), "safeguard_factor must be non-negative"),
-        (dict(dim=DIM, mem=MEM, max_weight_norm=0.0), "max_weight_norm must be positive"),
+        (dict(dim=DIM, mem=MEM, relaxation=float("nan")), "relaxation must be finite"),
+        (dict(dim=DIM, mem=MEM, relaxation=float("inf")), "relaxation must be finite"),
+        (dict(dim=DIM, mem=MEM, relaxation=3.0), "relaxation must be finite and in \\[0, 2\\]"),
+        (dict(dim=DIM, mem=MEM, safeguard_factor=float("nan")), "safeguard_factor must be finite"),
+        (dict(dim=DIM, mem=MEM, safeguard_factor=float("inf")), "safeguard_factor must be finite"),
+        (dict(dim=DIM, mem=MEM, safeguard_factor=-1.0), "safeguard_factor must be finite and non-negative"),
+        (dict(dim=DIM, mem=MEM, max_weight_norm=float("nan")), "max_weight_norm must be finite"),
+        (dict(dim=DIM, mem=MEM, max_weight_norm=float("inf")), "max_weight_norm must be finite"),
+        (dict(dim=DIM, mem=MEM, max_weight_norm=0.0), "max_weight_norm must be finite and positive"),
     ],
 )
 def test_construct_invalid_args_raise_value_error(kwargs, message):


### PR DESCRIPTION
## Summary
- reject NaN/Inf values for relaxation, safeguard_factor, and max_weight_norm in C and Python entry points
- update C API docs for finite scalar requirements
- add C and Python validation coverage for non-finite scalar options

## Tests
- make test
- venv/bin/python -m pip install -e . && venv/bin/python -m pytest tests/python/test_aa.py -q