### PR TITLE
Check AA allocation dimensions

### DIFF
--- a/src/aa.c
+++ b/src/aa.c
@@ -31,6 +31,7 @@
  */
 
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 
 #include "aa.h"
@@ -44,6 +45,10 @@
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+static int size_mul_overflows(size_t a, size_t b) {
+  return b != 0 && a > ((size_t)-1) / b;
+}
 
 #if PROFILING > 0
 
@@ -612,6 +617,10 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
   TIME_TIC
   AaWork *a;
   aa_int mem_clamped = MIN(mem, dim);
+  aa_int aug_rows = 0;
+  size_t dim_mem_count = 0;
+  size_t aug_mem_count = 0;
+  size_t mem_mem_count = 0;
   /* `regularization` is accepted with either sign: positive = scaled by
    * ||A||_F ||Y||_F; negative = pinned absolute |regularization|; zero = off.
    * Only NaN / non-finite values are rejected (via the !isfinite check).
@@ -627,6 +636,37 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
       (mem_clamped > 0 && min_len < 1)) {
     printf("Invalid AA parameters.\n");
     return (AaWork *)0;
+  }
+  if (mem_clamped > 0) {
+    size_t dim_count = (size_t)dim;
+    size_t mem_count = (size_t)mem_clamped;
+    size_t max_elem_size = sizeof(aa_float) > sizeof(blas_int)
+                               ? sizeof(aa_float)
+                               : sizeof(blas_int);
+    size_t max_alloc_count = ((size_t)-1) / max_elem_size;
+    if (dim > INT_MAX - mem_clamped) {
+      printf("Invalid AA dimensions.\n");
+      return (AaWork *)0;
+    }
+    aug_rows = dim + mem_clamped;
+    if (size_mul_overflows(dim_count, mem_count) ||
+        size_mul_overflows((size_t)aug_rows, mem_count) ||
+        size_mul_overflows(mem_count, mem_count)) {
+      printf("Invalid AA dimensions.\n");
+      return (AaWork *)0;
+    }
+    dim_mem_count = dim_count * mem_count;
+    aug_mem_count = (size_t)aug_rows * mem_count;
+    mem_mem_count = mem_count * mem_count;
+    if (dim_count > max_alloc_count ||
+        mem_count > max_alloc_count ||
+        (size_t)aug_rows > max_alloc_count ||
+        dim_mem_count > max_alloc_count ||
+        aug_mem_count > max_alloc_count ||
+        mem_mem_count > max_alloc_count) {
+      printf("Invalid AA dimensions.\n");
+      return (AaWork *)0;
+    }
   }
   a = (AaWork *)calloc(1, sizeof(AaWork));
   if (!a) {
@@ -664,14 +704,13 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
 
   a->g_prev = (aa_float *)calloc(a->dim, sizeof(aa_float));
 
-  a->Y = (aa_float *)calloc(a->dim * a->mem, sizeof(aa_float));
-  a->S = (aa_float *)calloc(a->dim * a->mem, sizeof(aa_float));
-  a->D = (aa_float *)calloc(a->dim * a->mem, sizeof(aa_float));
+  a->Y = (aa_float *)calloc(dim_mem_count, sizeof(aa_float));
+  a->S = (aa_float *)calloc(dim_mem_count, sizeof(aa_float));
+  a->D = (aa_float *)calloc(dim_mem_count, sizeof(aa_float));
 
   {
-    aa_int aug_rows = a->dim + a->mem;
-    a->A_aug = (aa_float *)calloc((size_t)aug_rows * a->mem, sizeof(aa_float));
-    a->c_aug = (aa_float *)calloc((size_t)aug_rows, sizeof(aa_float));
+    a->A_aug = (aa_float *)calloc(aug_mem_count, sizeof(aa_float));
+    a->c_aug = (aa_float *)calloc(aug_rows, sizeof(aa_float));
     a->tau = (aa_float *)calloc(a->mem, sizeof(aa_float));
     a->jpvt = (blas_int *)calloc(a->mem, sizeof(blas_int));
 
@@ -688,9 +727,9 @@ AaWork *aa_init(aa_int dim, aa_int mem, aa_int min_len, aa_int type1,
      * W_orig preserves W across gesv so iterative refinement can form
      * the residual c_top − W γ. */
     if (type1) {
-      a->B_aug = (aa_float *)calloc((size_t)aug_rows * a->mem, sizeof(aa_float));
-      a->W = (aa_float *)calloc((size_t)a->mem * a->mem, sizeof(aa_float));
-      a->W_orig = (aa_float *)calloc((size_t)a->mem * a->mem, sizeof(aa_float));
+      a->B_aug = (aa_float *)calloc(aug_mem_count, sizeof(aa_float));
+      a->W = (aa_float *)calloc(mem_mem_count, sizeof(aa_float));
+      a->W_orig = (aa_float *)calloc(mem_mem_count, sizeof(aa_float));
       a->ipiv = (blas_int *)calloc(a->mem, sizeof(blas_int));
     } else {
       a->B_aug = NULL;

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -10,6 +10,7 @@
  */
 #include "aa.h"
 #include "aa_blas.h"
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -249,6 +250,17 @@ static const char *test_mem_zero_is_noop(void) {
 static const char *test_dim_zero_rejected(void) {
   AaWork *a = aa_init(0, 1, /*min_len=*/1, 1, 1e-8, 1.0, 2.0, 1e10, 5, 0);
   mu_assert("aa_init(dim=0) should return NULL", a == NULL);
+  return 0;
+}
+
+static const char *test_dimension_overflow_rejected(void) {
+  AaWork *a = aa_init(INT_MAX, 1, /*min_len=*/1, 1, 1e-8, 1.0, 2.0,
+                      1e10, 5, 0);
+  mu_assert("aa_init should reject dim+mem overflow", a == NULL);
+
+  a = aa_init(INT_MAX, INT_MAX, /*min_len=*/1, 1, 1e-8, 1.0, 2.0,
+              1e10, 5, 0);
+  mu_assert("aa_init should reject oversized dim/mem dimensions", a == NULL);
   return 0;
 }
 
@@ -1007,6 +1019,8 @@ static const char *all_tests(void) {
   mu_run_test(test_mem_zero_is_noop);
   printf("unit: dim=0 is rejected\n");
   mu_run_test(test_dim_zero_rejected);
+  printf("unit: overflowing dimensions are rejected\n");
+  mu_run_test(test_dimension_overflow_rejected);
   printf("unit: negative ir_max_steps is rejected\n");
   mu_run_test(test_ir_max_steps_negative_rejected);
   printf("unit: ir_max_steps=0 (IR disabled) still solves\n");


### PR DESCRIPTION
## Summary
- add a small allocation-size overflow check for AA workspace dimensions
- precompute the large allocation counts used by the existing calloc calls
- add a C regression for dimensions that overflow the augmented row count

## Tests
- make test
- venv/bin/python -m pytest tests/python/test_aa.py -q