### PR TITLE
Stabilize scaled regularization product

### DIFF
--- a/src/aa.c
+++ b/src/aa.c
@@ -38,12 +38,41 @@
 
 #ifndef SFLOAT
 #define AA_EPS DBL_EPSILON
+#define AA_FLOAT_MAX DBL_MAX
 #else
 #define AA_EPS FLT_EPSILON
+#define AA_FLOAT_MAX FLT_MAX
 #endif
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/* Compute x*y*z for nonnegative finite values without letting an
+ * intermediate product overflow or underflow when the final result is still
+ * representable. If the true result exceeds aa_float range, clamp to the
+ * largest finite value; if it is below the subnormal floor, ldexp returns 0. */
+static aa_float scaled_product3(aa_float x, aa_float y, aa_float z) {
+  int ex, ey, ez, emax, e;
+  aa_float mx, my, mz, m, mmax;
+
+  if (x == 0 || y == 0 || z == 0) return 0;
+  if (!isfinite(x) || !isfinite(y) || !isfinite(z)) return NAN;
+
+  mx = frexp(x, &ex);
+  my = frexp(y, &ey);
+  mz = frexp(z, &ez);
+  m = mx * my * mz;
+  e = ex + ey + ez;
+
+  while (m > 0 && m < 0.5) {
+    m *= 2;
+    e--;
+  }
+
+  mmax = frexp(AA_FLOAT_MAX, &emax);
+  if (e > emax || (e == emax && m > mmax)) return AA_FLOAT_MAX;
+  return ldexp(m, e);
+}
 
 #if PROFILING > 0
 
@@ -232,7 +261,7 @@ static aa_float compute_regularization(AaWork *a) {
   TIME_TIC
   aa_float nrm_y = frob_from_col_norms(a->nrm_y_col, a->mem);
   aa_float nrm_a = a->type1 ? frob_from_col_norms(a->nrm_s_col, a->mem) : nrm_y;
-  aa_float r = a->regularization * nrm_a * nrm_y;
+  aa_float r = scaled_product3(a->regularization, nrm_a, nrm_y);
   if (a->verbosity > 2) {
     printf("iter: %i, ||A||_F %.2e, ||Y||_F %.2e, r: %.2e\n",
            (int)a->iter, nrm_a, nrm_y, r);

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -31,6 +31,14 @@
 #define PRINT_INTERVAL (500)
 #define VERBOSITY (1)
 
+#ifndef SFLOAT
+#define REG_SCALE_HI (1e200)
+#define REG_SCALE_LO (1e-200)
+#else
+#define REG_SCALE_HI (1e30f)
+#define REG_SCALE_LO (1e-30f)
+#endif
+
 int tests_run = 0;
 
 #ifdef _WIN32
@@ -691,6 +699,55 @@ static const char *test_pinned_regularization(void) {
   return 0;
 }
 
+/* Scaled regularization is r = reg * ||A||_F * ||Y||_F. This must be
+ * computed without overflowing/underflowing intermediate products when the
+ * final r is representable. */
+static const char *test_scaled_regularization_extreme_intermediates(void) {
+  const aa_float hi = (aa_float)REG_SCALE_HI;
+  const aa_float lo = (aa_float)REG_SCALE_LO;
+  AaStats s;
+
+  {
+    AaWork *a = aa_init(2, 1, /*min_len=*/1, /*type1=*/1, hi,
+                        /*relax=*/1.0, /*safeguard=*/2.0,
+                        /*max_w=*/hi, /*ir_max_steps=*/5, /*verbosity=*/0);
+    aa_float x0[2] = {0.0, 0.0};
+    aa_float f0[2] = {0.0, 0.0};
+    aa_float x1[2] = {hi, lo};
+    aa_float f1[2] = {hi, 0.0};
+    aa_apply(f0, x0, a);
+    aa_apply(f1, x1, a);
+    s = aa_get_stats(a);
+    aa_finish(a);
+    mu_assert("scaled r overflowed despite finite true product",
+              isfinite(s.last_regularization));
+    mu_assert("scaled r lost high-scale finite product",
+              s.last_regularization > hi * (aa_float)0.1);
+    mu_assert("scaled r high-scale product is unexpectedly large",
+              s.last_regularization < hi * (aa_float)10.0);
+  }
+
+  {
+    AaWork *a = aa_init(2, 1, /*min_len=*/1, /*type1=*/1, lo,
+                        /*relax=*/1.0, /*safeguard=*/2.0,
+                        /*max_w=*/hi, /*ir_max_steps=*/5, /*verbosity=*/0);
+    aa_float x0[2] = {0.0, 0.0};
+    aa_float f0[2] = {0.0, 0.0};
+    aa_float x1[2] = {lo, 0.0};
+    aa_float f1[2] = {lo, -hi};
+    aa_apply(f0, x0, a);
+    aa_apply(f1, x1, a);
+    s = aa_get_stats(a);
+    aa_finish(a);
+    mu_assert("scaled r underflowed despite finite true product",
+              s.last_regularization > 0);
+    mu_assert("scaled r low-scale product is unexpectedly large",
+              s.last_regularization < lo * (aa_float)10.0);
+  }
+
+  return 0;
+}
+
 /* min_len=1: AA should start extrapolating on iter 1 (as soon as the first
  * residual pair is buffered) and still converge comparably to min_len=mem
  * on a well-conditioned problem. Without min_len you couldn't get this
@@ -1055,6 +1112,8 @@ static const char *all_tests(void) {
   mu_run_test(test_rank_deficient_memory_oversized_mem);
   printf("unit: pinned regularization mode works\n");
   mu_run_test(test_pinned_regularization);
+  printf("unit: scaled regularization handles extreme intermediates\n");
+  mu_run_test(test_scaled_regularization_extreme_intermediates);
   printf("unit: AA accelerates convergence vs plain GD\n");
   mu_run_test(test_aa_accelerates_convergence);
   printf("unit: aa_get_stats basic counters\n");

--- a/tests/c/run_tests.c
+++ b/tests/c/run_tests.c
@@ -34,9 +34,11 @@
 #ifndef SFLOAT
 #define REG_SCALE_HI (1e200)
 #define REG_SCALE_LO (1e-200)
+#define REG_SCALE_MID (1e154)
 #else
 #define REG_SCALE_HI (1e30f)
 #define REG_SCALE_LO (1e-30f)
+#define REG_SCALE_MID (1e18f)
 #endif
 
 int tests_run = 0;
@@ -705,6 +707,8 @@ static const char *test_pinned_regularization(void) {
 static const char *test_scaled_regularization_extreme_intermediates(void) {
   const aa_float hi = (aa_float)REG_SCALE_HI;
   const aa_float lo = (aa_float)REG_SCALE_LO;
+  const aa_float mid = (aa_float)REG_SCALE_MID;
+  const aa_float inv_mid = (aa_float)(1.0 / REG_SCALE_MID);
   AaStats s;
 
   {
@@ -713,8 +717,8 @@ static const char *test_scaled_regularization_extreme_intermediates(void) {
                         /*max_w=*/hi, /*ir_max_steps=*/5, /*verbosity=*/0);
     aa_float x0[2] = {0.0, 0.0};
     aa_float f0[2] = {0.0, 0.0};
-    aa_float x1[2] = {hi, lo};
-    aa_float f1[2] = {hi, 0.0};
+    aa_float x1[2] = {mid, inv_mid};
+    aa_float f1[2] = {mid, 0.0};
     aa_apply(f0, x0, a);
     aa_apply(f1, x1, a);
     s = aa_get_stats(a);
@@ -733,8 +737,8 @@ static const char *test_scaled_regularization_extreme_intermediates(void) {
                         /*max_w=*/hi, /*ir_max_steps=*/5, /*verbosity=*/0);
     aa_float x0[2] = {0.0, 0.0};
     aa_float f0[2] = {0.0, 0.0};
-    aa_float x1[2] = {lo, 0.0};
-    aa_float f1[2] = {lo, -hi};
+    aa_float x1[2] = {inv_mid, 0.0};
+    aa_float f1[2] = {inv_mid, -mid};
     aa_apply(f0, x0, a);
     aa_apply(f1, x1, a);
     s = aa_get_stats(a);


### PR DESCRIPTION
## Summary
- compute scaled regularization via mantissa/exponent arithmetic to avoid intermediate overflow or underflow
- clamp only truly out-of-range products to the largest finite aa_float value
- add C coverage for finite high-scale and low-scale products that naive multiplication would mishandle

## Tests
- make test
- venv/bin/python -m pip install -e . && venv/bin/python -m pytest tests/python/test_aa.py -q