### PR TITLE
[codex] Replace Node 20 MSVC setup action

### DIFF
--- a/.github/workflows/mkl.yml
+++ b/.github/workflows/mkl.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: egor-tensin/vs-shell@v2
 
       - uses: conda-incubator/setup-miniconda@v4
         with:

--- a/.github/workflows/windows-c.yml
+++ b/.github/workflows/windows-c.yml
@@ -27,7 +27,7 @@ jobs:
           "$root/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: egor-tensin/vs-shell@v2
 
       - name: Build C Library
         shell: cmd


### PR DESCRIPTION
## Summary

Replace `ilammy/msvc-dev-cmd@v1` with the composite `egor-tensin/vs-shell@v2` action in Windows workflows.

## Why

`ilammy/msvc-dev-cmd@v1` still declares a Node 20 runtime, and the latest checked release does not provide a Node 24 runtime. The replacement action is composite and sets up the Visual Studio shell without a Node runtime dependency.

## Validation

- Inspected workflow diffs
- Ran `git diff --check`
- Verified changed workflow action metadata no longer reports `node20`